### PR TITLE
Rotate snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ Global Flags:
 
 ```
 
+### Rotate snapshots
+
+```
+Removes snapshots older than the given age, where default is 30 days.
+You are required to set a `destination` flag, which represents the
+environment where your snapshots are stored.
+
+Usage:
+  esnap rotate [flags]
+
+  Flags:
+    -a, --age int   Maximun age in days to keep snapshots (default 30)
+
+    Global Flags:
+          --config string        config file (default is $HOME/.esnap.yaml)
+	    -d, --destination string   Destination for the command action
+
+```
+
 ### Cleanup indices
 
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ var destination *string
 var createRepositoryTake *bool
 var originRestore, snapshot *string
 var allIndices, fresh *bool
+var age *int
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.

--- a/cmd/rotate.go
+++ b/cmd/rotate.go
@@ -49,6 +49,7 @@ var rotateCmd = &cobra.Command{
 		}
 
 		log.Printf("Found %d snapshots on %s", len(res.Snapshots), *destination)
+		log.Printf("Deleting snapshots older than %v", limit)
 		for _, snapshot := range res.Snapshots {
 			if int64(limit.Sub(snapshot.StartTime)) > 0 {
 				if _, err := conn.DeleteSnapshot(*destination, snapshot.Snapshot); err != nil {

--- a/cmd/rotate.go
+++ b/cmd/rotate.go
@@ -1,0 +1,70 @@
+// Copyright © 2016 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	es "github.com/bebanjo/elastigo/lib"
+	"github.com/spf13/cobra"
+)
+
+// rotateCmd represents the rotate command
+var rotateCmd = &cobra.Command{
+	Use:   "rotate",
+	Short: "Rotate snapshots",
+	Long:  `Removes snapshots older than the given age, where default is 30 days.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var conn = es.NewConn()
+		var now = time.Now()
+		var limit = now.Add(-time.Duration(24**age) * time.Hour)
+		var count int
+
+		// Destination is required
+		if *destination == "" {
+			fmt.Fprintf(os.Stderr, "destination is required\n")
+			os.Exit(1)
+		}
+
+		log.Println("Fetching snapshots...")
+		res, err := conn.GetSnapshots(*destination, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "rotate: error %v\n", err)
+			os.Exit(1)
+		}
+
+		log.Printf("Found %d snapshots on %s", len(res.Snapshots), *destination)
+		for _, snapshot := range res.Snapshots {
+			if int64(limit.Sub(snapshot.StartTime)) > 0 {
+				if _, err := conn.DeleteSnapshot(*destination, snapshot.Snapshot); err != nil {
+					fmt.Fprintf(os.Stderr, "rotate: error deleting snapshot %v\n", err)
+				} else {
+					log.Printf("Removed snapshot %s from %s", snapshot.Snapshot, *destination)
+					count++
+				}
+			}
+		}
+		log.Printf("%d snapshots on %s were rotated", count, *destination)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(rotateCmd)
+
+	age = rotateCmd.PersistentFlags().IntP("age", "a", 30, "Maximun age in days to keep snapshots")
+}

--- a/vendor/github.com/bebanjo/elastigo/lib/catnodeinfo.go
+++ b/vendor/github.com/bebanjo/elastigo/lib/catnodeinfo.go
@@ -20,7 +20,7 @@ func newCatNodeInfo(fields []string, indexLine string) (catNode *CatNodeInfo, er
 		return nil, fmt.Errorf("Number of fields (%d) greater than number of stats (%d)", lf, ls)
 	}
 
-	// Populate the apropriate field in CatNodeInfo
+	// Populate the appropriate field in CatNodeInfo
 	for i, field := range fields {
 
 		switch field {
@@ -164,7 +164,7 @@ func newCatNodeInfo(fields []string, indexLine string) (catNode *CatNodeInfo, er
 			catNode.PercTime = split[i]
 		case "percolate.total", "pto", "percolateTotal":
 			catNode.PercTotal = split[i]
-		case "refesh.total", "rto", "refreshTotal":
+		case "refresh.total", "rto", "refreshTotal":
 			catNode.RefreshTotal = split[i]
 		case "refresh.time", "rti", "refreshTime":
 			catNode.RefreshTime = split[i]

--- a/vendor/github.com/bebanjo/elastigo/lib/snapshot.go
+++ b/vendor/github.com/bebanjo/elastigo/lib/snapshot.go
@@ -118,3 +118,47 @@ func (c *Conn) getSnapshots(repository, name string, args map[string]interface{}
 
 	return retval, nil
 }
+
+// DeleteSnapshotRepository deletes a snapshot repository. When a repository is deleted, Elasticsearch
+// only removes the reference to the location where the repository is storing the snapshots.
+// The snapshots themselves are left untouched and in place.
+// http://www.elastic.co/guide/en/elasticsearch/reference/1.3/modules-snapshots.html
+func (c *Conn) DeleteSnapshotRepository(repository string) (BaseResponse, error) {
+	var url string
+	var retval BaseResponse
+	url = fmt.Sprintf("/_snapshot/%s", repository)
+	body, err := c.DoCommand("DELETE", url, nil, nil)
+	if err != nil {
+		return retval, err
+	}
+	if err == nil {
+		jsonErr := json.Unmarshal(body, &retval)
+		if jsonErr != nil {
+			return retval, jsonErr
+		}
+	}
+
+	return retval, nil
+}
+
+// DeleteSnapshot deletes a snapshot from a repository. Elasticsearch deletes all files that are
+// associated with the deleted snapshot and not used by any other snapshots.
+// http://www.elastic.co/guide/en/elasticsearch/reference/1.3/modules-snapshots.html
+func (c *Conn) DeleteSnapshot(repository, name string) (BaseResponse, error) {
+	var url string
+	var retval BaseResponse
+	url = fmt.Sprintf("/_snapshot/%s/%s", repository, name)
+	body, err := c.DoCommand("DELETE", url, nil, nil)
+	if err != nil {
+		return retval, err
+	}
+	if err == nil {
+		fmt.Println(string(body))
+		jsonErr := json.Unmarshal(body, &retval)
+		if jsonErr != nil {
+			return retval, jsonErr
+		}
+	}
+
+	return retval, nil
+}

--- a/vendor/github.com/bebanjo/elastigo/lib/snapshot.go
+++ b/vendor/github.com/bebanjo/elastigo/lib/snapshot.go
@@ -153,7 +153,6 @@ func (c *Conn) DeleteSnapshot(repository, name string) (BaseResponse, error) {
 		return retval, err
 	}
 	if err == nil {
-		fmt.Println(string(body))
 		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr

--- a/vendor/github.com/bmizerany/assert/assert.go
+++ b/vendor/github.com/bmizerany/assert/assert.go
@@ -1,0 +1,76 @@
+package assert
+// Testing helpers for doozer.
+
+import (
+	"github.com/kr/pretty"
+	"reflect"
+	"testing"
+	"runtime"
+	"fmt"
+)
+
+func assert(t *testing.T, result bool, f func(), cd int) {
+	if !result {
+		_, file, line, _ := runtime.Caller(cd + 1)
+		t.Errorf("%s:%d", file, line)
+		f()
+		t.FailNow()
+	}
+}
+
+func equal(t *testing.T, exp, got interface{}, cd int, args ...interface{}) {
+	fn := func() {
+		for _, desc := range pretty.Diff(exp, got) {
+			t.Error("!", desc)
+		}
+		if len(args) > 0 {
+			t.Error("!", " -", fmt.Sprint(args...))
+		}
+	}
+	result := reflect.DeepEqual(exp, got)
+	assert(t, result, fn, cd+1)
+}
+
+func tt(t *testing.T, result bool, cd int, args ...interface{}) {
+	fn := func() {
+		t.Errorf("!  Failure")
+		if len(args) > 0 {
+			t.Error("!", " -", fmt.Sprint(args...))
+		}
+	}
+	assert(t, result, fn, cd+1)
+}
+
+func T(t *testing.T, result bool, args ...interface{}) {
+	tt(t, result, 1, args...)
+}
+
+func Tf(t *testing.T, result bool, format string, args ...interface{}) {
+	tt(t, result, 1, fmt.Sprintf(format, args...))
+}
+
+func Equal(t *testing.T, exp, got interface{}, args ...interface{}) {
+	equal(t, exp, got, 1, args...)
+}
+
+func Equalf(t *testing.T, exp, got interface{}, format string, args ...interface{}) {
+	equal(t, exp, got, 1, fmt.Sprintf(format, args...))
+}
+
+func NotEqual(t *testing.T, exp, got interface{}, args ...interface{}) {
+	fn := func() {
+		t.Errorf("!  Unexpected: <%#v>", exp)
+		if len(args) > 0 {
+			t.Error("!", " -", fmt.Sprint(args...))
+		}
+	}
+	result := !reflect.DeepEqual(exp, got)
+	assert(t, result, fn, 1)
+}
+
+func Panic(t *testing.T, err interface{}, fn func()) {
+	defer func() {
+		equal(t, err, recover(), 3)
+	}()
+	fn()
+}

--- a/vendor/github.com/bmizerany/assert/example/point.go
+++ b/vendor/github.com/bmizerany/assert/example/point.go
@@ -1,0 +1,5 @@
+package point
+
+type Point struct {
+	X, Y int
+}

--- a/vendor/github.com/gopherjs/gopherjs/js/LICENSE
+++ b/vendor/github.com/gopherjs/gopherjs/js/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2013 Richard Musiol. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/gopherjs/gopherjs/js/js.go
+++ b/vendor/github.com/gopherjs/gopherjs/js/js.go
@@ -1,0 +1,168 @@
+// Package js provides functions for interacting with native JavaScript APIs. Calls to these functions are treated specially by GopherJS and translated directly to their corresponding JavaScript syntax.
+//
+// Use MakeWrapper to expose methods to JavaScript. When passing values directly, the following type conversions are performed:
+//
+//  | Go type               | JavaScript type       | Conversions back to interface{} |
+//  | --------------------- | --------------------- | ------------------------------- |
+//  | bool                  | Boolean               | bool                            |
+//  | integers and floats   | Number                | float64                         |
+//  | string                | String                | string                          |
+//  | []int8                | Int8Array             | []int8                          |
+//  | []int16               | Int16Array            | []int16                         |
+//  | []int32, []int        | Int32Array            | []int                           |
+//  | []uint8               | Uint8Array            | []uint8                         |
+//  | []uint16              | Uint16Array           | []uint16                        |
+//  | []uint32, []uint      | Uint32Array           | []uint                          |
+//  | []float32             | Float32Array          | []float32                       |
+//  | []float64             | Float64Array          | []float64                       |
+//  | all other slices      | Array                 | []interface{}                   |
+//  | arrays                | see slice type        | see slice type                  |
+//  | functions             | Function              | func(...interface{}) *js.Object |
+//  | time.Time             | Date                  | time.Time                       |
+//  | -                     | instanceof Node       | *js.Object                      |
+//  | maps, structs         | instanceof Object     | map[string]interface{}          |
+//
+// Additionally, for a struct containing a *js.Object field, only the content of the field will be passed to JavaScript and vice versa.
+package js
+
+// Object is a container for a native JavaScript object. Calls to its methods are treated specially by GopherJS and translated directly to their JavaScript syntax. A nil pointer to Object is equal to JavaScript's "null". Object can not be used as a map key.
+type Object struct{ object *Object }
+
+// Get returns the object's property with the given key.
+func (o *Object) Get(key string) *Object { return o.object.Get(key) }
+
+// Set assigns the value to the object's property with the given key.
+func (o *Object) Set(key string, value interface{}) { o.object.Set(key, value) }
+
+// Delete removes the object's property with the given key.
+func (o *Object) Delete(key string) { o.object.Delete(key) }
+
+// Length returns the object's "length" property, converted to int.
+func (o *Object) Length() int { return o.object.Length() }
+
+// Index returns the i'th element of an array.
+func (o *Object) Index(i int) *Object { return o.object.Index(i) }
+
+// SetIndex sets the i'th element of an array.
+func (o *Object) SetIndex(i int, value interface{}) { o.object.SetIndex(i, value) }
+
+// Call calls the object's method with the given name.
+func (o *Object) Call(name string, args ...interface{}) *Object { return o.object.Call(name, args...) }
+
+// Invoke calls the object itself. This will fail if it is not a function.
+func (o *Object) Invoke(args ...interface{}) *Object { return o.object.Invoke(args...) }
+
+// New creates a new instance of this type object. This will fail if it not a function (constructor).
+func (o *Object) New(args ...interface{}) *Object { return o.object.New(args...) }
+
+// Bool returns the object converted to bool according to JavaScript type conversions.
+func (o *Object) Bool() bool { return o.object.Bool() }
+
+// String returns the object converted to string according to JavaScript type conversions.
+func (o *Object) String() string { return o.object.String() }
+
+// Int returns the object converted to int according to JavaScript type conversions (parseInt).
+func (o *Object) Int() int { return o.object.Int() }
+
+// Int64 returns the object converted to int64 according to JavaScript type conversions (parseInt).
+func (o *Object) Int64() int64 { return o.object.Int64() }
+
+// Uint64 returns the object converted to uint64 according to JavaScript type conversions (parseInt).
+func (o *Object) Uint64() uint64 { return o.object.Uint64() }
+
+// Float returns the object converted to float64 according to JavaScript type conversions (parseFloat).
+func (o *Object) Float() float64 { return o.object.Float() }
+
+// Interface returns the object converted to interface{}. See GopherJS' README for details.
+func (o *Object) Interface() interface{} { return o.object.Interface() }
+
+// Unsafe returns the object as an uintptr, which can be converted via unsafe.Pointer. Not intended for public use.
+func (o *Object) Unsafe() uintptr { return o.object.Unsafe() }
+
+// Error encapsulates JavaScript errors. Those are turned into a Go panic and may be recovered, giving an *Error that holds the JavaScript error object.
+type Error struct {
+	*Object
+}
+
+// Error returns the message of the encapsulated JavaScript error object.
+func (err *Error) Error() string {
+	return "JavaScript error: " + err.Get("message").String()
+}
+
+// Stack returns the stack property of the encapsulated JavaScript error object.
+func (err *Error) Stack() string {
+	return err.Get("stack").String()
+}
+
+// Global gives JavaScript's global object ("window" for browsers and "GLOBAL" for Node.js).
+var Global *Object
+
+// Module gives the value of the "module" variable set by Node.js. Hint: Set a module export with 'js.Module.Get("exports").Set("exportName", ...)'.
+var Module *Object
+
+// Undefined gives the JavaScript value "undefined".
+var Undefined *Object
+
+// Debugger gets compiled to JavaScript's "debugger;" statement.
+func Debugger() {}
+
+// InternalObject returns the internal JavaScript object that represents i. Not intended for public use.
+func InternalObject(i interface{}) *Object {
+	return nil
+}
+
+// MakeFunc wraps a function and gives access to the values of JavaScript's "this" and "arguments" keywords.
+func MakeFunc(fn func(this *Object, arguments []*Object) interface{}) *Object {
+	return Global.Call("$makeFunc", InternalObject(fn))
+}
+
+// Keys returns the keys of the given JavaScript object.
+func Keys(o *Object) []string {
+	if o == nil || o == Undefined {
+		return nil
+	}
+	a := Global.Get("Object").Call("keys", o)
+	s := make([]string, a.Length())
+	for i := 0; i < a.Length(); i++ {
+		s[i] = a.Index(i).String()
+	}
+	return s
+}
+
+// MakeWrapper creates a JavaScript object which has wrappers for the exported methods of i. Use explicit getter and setter methods to expose struct fields to JavaScript.
+func MakeWrapper(i interface{}) *Object {
+	v := InternalObject(i)
+	o := Global.Get("Object").New()
+	o.Set("__internal_object__", v)
+	methods := v.Get("constructor").Get("methods")
+	for i := 0; i < methods.Length(); i++ {
+		m := methods.Index(i)
+		if m.Get("pkg").String() != "" { // not exported
+			continue
+		}
+		o.Set(m.Get("name").String(), func(args ...*Object) *Object {
+			return Global.Call("$externalizeFunction", v.Get(m.Get("prop").String()), m.Get("typ"), true).Call("apply", v, args)
+		})
+	}
+	return o
+}
+
+// NewArrayBuffer creates a JavaScript ArrayBuffer from a byte slice.
+func NewArrayBuffer(b []byte) *Object {
+	slice := InternalObject(b)
+	offset := slice.Get("$offset").Int()
+	length := slice.Get("$length").Int()
+	return slice.Get("$array").Get("buffer").Call("slice", offset, offset+length)
+}
+
+// M is a simple map type. It is intended as a shorthand for JavaScript objects (before conversion).
+type M map[string]interface{}
+
+// S is a simple slice type. It is intended as a shorthand for JavaScript arrays (before conversion).
+type S []interface{}
+
+func init() {
+	// avoid dead code elimination
+	e := Error{}
+	_ = e
+}

--- a/vendor/github.com/jtolds/gls/LICENSE
+++ b/vendor/github.com/jtolds/gls/LICENSE
@@ -1,0 +1,18 @@
+Copyright (c) 2013, Space Monkey, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jtolds/gls/context.go
+++ b/vendor/github.com/jtolds/gls/context.go
@@ -1,0 +1,144 @@
+// Package gls implements goroutine-local storage.
+package gls
+
+import (
+	"sync"
+)
+
+const (
+	maxCallers = 64
+)
+
+var (
+	stackTagPool   = &idPool{}
+	mgrRegistry    = make(map[*ContextManager]bool)
+	mgrRegistryMtx sync.RWMutex
+)
+
+// Values is simply a map of key types to value types. Used by SetValues to
+// set multiple values at once.
+type Values map[interface{}]interface{}
+
+// ContextManager is the main entrypoint for interacting with
+// Goroutine-local-storage. You can have multiple independent ContextManagers
+// at any given time. ContextManagers are usually declared globally for a given
+// class of context variables. You should use NewContextManager for
+// construction.
+type ContextManager struct {
+	mtx    sync.RWMutex
+	values map[uint]Values
+}
+
+// NewContextManager returns a brand new ContextManager. It also registers the
+// new ContextManager in the ContextManager registry which is used by the Go
+// method. ContextManagers are typically defined globally at package scope.
+func NewContextManager() *ContextManager {
+	mgr := &ContextManager{values: make(map[uint]Values)}
+	mgrRegistryMtx.Lock()
+	defer mgrRegistryMtx.Unlock()
+	mgrRegistry[mgr] = true
+	return mgr
+}
+
+// Unregister removes a ContextManager from the global registry, used by the
+// Go method. Only intended for use when you're completely done with a
+// ContextManager. Use of Unregister at all is rare.
+func (m *ContextManager) Unregister() {
+	mgrRegistryMtx.Lock()
+	defer mgrRegistryMtx.Unlock()
+	delete(mgrRegistry, m)
+}
+
+// SetValues takes a collection of values and a function to call for those
+// values to be set in. Anything further down the stack will have the set
+// values available through GetValue. SetValues will add new values or replace
+// existing values of the same key and will not mutate or change values for
+// previous stack frames.
+// SetValues is slow (makes a copy of all current and new values for the new
+// gls-context) in order to reduce the amount of lookups GetValue requires.
+func (m *ContextManager) SetValues(new_values Values, context_call func()) {
+	if len(new_values) == 0 {
+		context_call()
+		return
+	}
+
+	tags := readStackTags(1)
+
+	m.mtx.Lock()
+	values := new_values
+	for _, tag := range tags {
+		if existing_values, ok := m.values[tag]; ok {
+			// oh, we found existing values, let's make a copy
+			values = make(Values, len(existing_values)+len(new_values))
+			for key, val := range existing_values {
+				values[key] = val
+			}
+			for key, val := range new_values {
+				values[key] = val
+			}
+			break
+		}
+	}
+	new_tag := stackTagPool.Acquire()
+	m.values[new_tag] = values
+	m.mtx.Unlock()
+	defer func() {
+		m.mtx.Lock()
+		delete(m.values, new_tag)
+		m.mtx.Unlock()
+		stackTagPool.Release(new_tag)
+	}()
+
+	addStackTag(new_tag, context_call)
+}
+
+// GetValue will return a previously set value, provided that the value was set
+// by SetValues somewhere higher up the stack. If the value is not found, ok
+// will be false.
+func (m *ContextManager) GetValue(key interface{}) (value interface{}, ok bool) {
+
+	tags := readStackTags(1)
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	for _, tag := range tags {
+		if values, ok := m.values[tag]; ok {
+			value, ok := values[key]
+			return value, ok
+		}
+	}
+	return "", false
+}
+
+func (m *ContextManager) getValues() Values {
+	tags := readStackTags(2)
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	for _, tag := range tags {
+		if values, ok := m.values[tag]; ok {
+			return values
+		}
+	}
+	return nil
+}
+
+// Go preserves ContextManager values and Goroutine-local-storage across new
+// goroutine invocations. The Go method makes a copy of all existing values on
+// all registered context managers and makes sure they are still set after
+// kicking off the provided function in a new goroutine. If you don't use this
+// Go method instead of the standard 'go' keyword, you will lose values in
+// ContextManagers, as goroutines have brand new stacks.
+func Go(cb func()) {
+	mgrRegistryMtx.RLock()
+	defer mgrRegistryMtx.RUnlock()
+
+	for mgr, _ := range mgrRegistry {
+		values := mgr.getValues()
+		if len(values) > 0 {
+			mgr_copy := mgr
+			cb_copy := cb
+			cb = func() { mgr_copy.SetValues(values, cb_copy) }
+		}
+	}
+
+	go cb()
+}

--- a/vendor/github.com/jtolds/gls/gen_sym.go
+++ b/vendor/github.com/jtolds/gls/gen_sym.go
@@ -1,0 +1,13 @@
+package gls
+
+var (
+	symPool = &idPool{}
+)
+
+// ContextKey is a throwaway value you can use as a key to a ContextManager
+type ContextKey struct{ id uint }
+
+// GenSym will return a brand new, never-before-used ContextKey
+func GenSym() ContextKey {
+	return ContextKey{id: symPool.Acquire()}
+}

--- a/vendor/github.com/jtolds/gls/id_pool.go
+++ b/vendor/github.com/jtolds/gls/id_pool.go
@@ -1,0 +1,34 @@
+package gls
+
+// though this could probably be better at keeping ids smaller, the goal of
+// this class is to keep a registry of the smallest unique integer ids
+// per-process possible
+
+import (
+	"sync"
+)
+
+type idPool struct {
+	mtx      sync.Mutex
+	released []uint
+	max_id   uint
+}
+
+func (p *idPool) Acquire() (id uint) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	if len(p.released) > 0 {
+		id = p.released[len(p.released)-1]
+		p.released = p.released[:len(p.released)-1]
+		return id
+	}
+	id = p.max_id
+	p.max_id++
+	return id
+}
+
+func (p *idPool) Release(id uint) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.released = append(p.released, id)
+}

--- a/vendor/github.com/jtolds/gls/stack_tags.go
+++ b/vendor/github.com/jtolds/gls/stack_tags.go
@@ -1,0 +1,43 @@
+package gls
+
+// so, basically, we're going to encode integer tags in base-16 on the stack
+
+const (
+	bitWidth = 4
+)
+
+func addStackTag(tag uint, context_call func()) {
+	if context_call == nil {
+		return
+	}
+	markS(tag, context_call)
+}
+
+func markS(tag uint, cb func()) { _m(tag, cb) }
+func mark0(tag uint, cb func()) { _m(tag, cb) }
+func mark1(tag uint, cb func()) { _m(tag, cb) }
+func mark2(tag uint, cb func()) { _m(tag, cb) }
+func mark3(tag uint, cb func()) { _m(tag, cb) }
+func mark4(tag uint, cb func()) { _m(tag, cb) }
+func mark5(tag uint, cb func()) { _m(tag, cb) }
+func mark6(tag uint, cb func()) { _m(tag, cb) }
+func mark7(tag uint, cb func()) { _m(tag, cb) }
+func mark8(tag uint, cb func()) { _m(tag, cb) }
+func mark9(tag uint, cb func()) { _m(tag, cb) }
+func markA(tag uint, cb func()) { _m(tag, cb) }
+func markB(tag uint, cb func()) { _m(tag, cb) }
+func markC(tag uint, cb func()) { _m(tag, cb) }
+func markD(tag uint, cb func()) { _m(tag, cb) }
+func markE(tag uint, cb func()) { _m(tag, cb) }
+func markF(tag uint, cb func()) { _m(tag, cb) }
+
+var pc_lookup = make(map[uintptr]int8, 17)
+var mark_lookup [16]func(uint, func())
+
+func _m(tag_remainder uint, cb func()) {
+	if tag_remainder == 0 {
+		cb()
+	} else {
+		mark_lookup[tag_remainder&0xf](tag_remainder>>bitWidth, cb)
+	}
+}

--- a/vendor/github.com/jtolds/gls/stack_tags_js.go
+++ b/vendor/github.com/jtolds/gls/stack_tags_js.go
@@ -1,0 +1,101 @@
+// +build js
+
+package gls
+
+// This file is used for GopherJS builds, which don't have normal runtime support
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+var stackRE = regexp.MustCompile("\\s+at (\\S*) \\([^:]+:(\\d+):(\\d+)")
+
+func findPtr() uintptr {
+	jsStack := js.Global.Get("Error").New().Get("stack").Call("split", "\n")
+	for i := 1; i < jsStack.Get("length").Int(); i++ {
+		item := jsStack.Index(i).String()
+		matches := stackRE.FindAllStringSubmatch(item, -1)
+		if matches == nil {
+			return 0
+		}
+		pkgPath := matches[0][1]
+		if strings.HasPrefix(pkgPath, "$packages.github.com/jtolds/gls.mark") {
+			line, _ := strconv.Atoi(matches[0][2])
+			char, _ := strconv.Atoi(matches[0][3])
+			x := (uintptr(line) << 16) | uintptr(char)
+			return x
+		}
+	}
+
+	return 0
+}
+
+func init() {
+	setEntries := func(f func(uint, func()), v int8) {
+		var ptr uintptr
+		f(0, func() {
+			ptr = findPtr()
+		})
+		pc_lookup[ptr] = v
+		if v >= 0 {
+			mark_lookup[v] = f
+		}
+	}
+	setEntries(markS, -0x1)
+	setEntries(mark0, 0x0)
+	setEntries(mark1, 0x1)
+	setEntries(mark2, 0x2)
+	setEntries(mark3, 0x3)
+	setEntries(mark4, 0x4)
+	setEntries(mark5, 0x5)
+	setEntries(mark6, 0x6)
+	setEntries(mark7, 0x7)
+	setEntries(mark8, 0x8)
+	setEntries(mark9, 0x9)
+	setEntries(markA, 0xa)
+	setEntries(markB, 0xb)
+	setEntries(markC, 0xc)
+	setEntries(markD, 0xd)
+	setEntries(markE, 0xe)
+	setEntries(markF, 0xf)
+}
+
+func currentStack(skip int) (stack []uintptr) {
+	jsStack := js.Global.Get("Error").New().Get("stack").Call("split", "\n")
+	for i := skip + 2; i < jsStack.Get("length").Int(); i++ {
+		item := jsStack.Index(i).String()
+		matches := stackRE.FindAllStringSubmatch(item, -1)
+		if matches == nil {
+			return stack
+		}
+		line, _ := strconv.Atoi(matches[0][2])
+		char, _ := strconv.Atoi(matches[0][3])
+		x := (uintptr(line) << 16) | uintptr(char)&0xffff
+		stack = append(stack, x)
+	}
+
+	return stack
+}
+
+func readStackTags(skip int) (tags []uint) {
+	stack := currentStack(skip)
+	var current_tag uint
+	for _, pc := range stack {
+		val, ok := pc_lookup[pc]
+		if !ok {
+			continue
+		}
+		if val < 0 {
+			tags = append(tags, current_tag)
+			current_tag = 0
+			continue
+		}
+		current_tag <<= bitWidth
+		current_tag += uint(val)
+	}
+	return
+}

--- a/vendor/github.com/jtolds/gls/stack_tags_main.go
+++ b/vendor/github.com/jtolds/gls/stack_tags_main.go
@@ -1,0 +1,61 @@
+// +build !js
+
+package gls
+
+// This file is used for standard Go builds, which have the expected runtime support
+
+import (
+	"reflect"
+	"runtime"
+)
+
+func init() {
+	setEntries := func(f func(uint, func()), v int8) {
+		pc_lookup[reflect.ValueOf(f).Pointer()] = v
+		if v >= 0 {
+			mark_lookup[v] = f
+		}
+	}
+	setEntries(markS, -0x1)
+	setEntries(mark0, 0x0)
+	setEntries(mark1, 0x1)
+	setEntries(mark2, 0x2)
+	setEntries(mark3, 0x3)
+	setEntries(mark4, 0x4)
+	setEntries(mark5, 0x5)
+	setEntries(mark6, 0x6)
+	setEntries(mark7, 0x7)
+	setEntries(mark8, 0x8)
+	setEntries(mark9, 0x9)
+	setEntries(markA, 0xa)
+	setEntries(markB, 0xb)
+	setEntries(markC, 0xc)
+	setEntries(markD, 0xd)
+	setEntries(markE, 0xe)
+	setEntries(markF, 0xf)
+}
+
+func currentStack(skip int) []uintptr {
+	stack := make([]uintptr, maxCallers)
+	return stack[:runtime.Callers(3+skip, stack)]
+}
+
+func readStackTags(skip int) (tags []uint) {
+	stack := currentStack(skip)
+	var current_tag uint
+	for _, pc := range stack {
+		pc = runtime.FuncForPC(pc).Entry()
+		val, ok := pc_lookup[pc]
+		if !ok {
+			continue
+		}
+		if val < 0 {
+			tags = append(tags, current_tag)
+			current_tag = 0
+			continue
+		}
+		current_tag <<= bitWidth
+		current_tag += uint(val)
+	}
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/LICENSE.md
+++ b/vendor/github.com/smartystreets/assertions/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2016 SmartyStreets, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+
+NOTE: Various optional and subordinate components carry their own licensing
+requirements and restrictions.  Use of those components is subject to the terms
+and conditions outlined the respective license of each component.

--- a/vendor/github.com/smartystreets/assertions/collections.go
+++ b/vendor/github.com/smartystreets/assertions/collections.go
@@ -1,0 +1,244 @@
+package assertions
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+// ShouldContain receives exactly two parameters. The first is a slice and the
+// second is a proposed member. Membership is determined using ShouldEqual.
+func ShouldContain(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	if matchError := oglematchers.Contains(expected[0]).Matches(actual); matchError != nil {
+		typeName := reflect.TypeOf(actual)
+
+		if fmt.Sprintf("%v", matchError) == "which is not a slice or array" {
+			return fmt.Sprintf(shouldHaveBeenAValidCollection, typeName)
+		}
+		return fmt.Sprintf(shouldHaveContained, typeName, expected[0])
+	}
+	return success
+}
+
+// ShouldNotContain receives exactly two parameters. The first is a slice and the
+// second is a proposed member. Membership is determinied using ShouldEqual.
+func ShouldNotContain(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	typeName := reflect.TypeOf(actual)
+
+	if matchError := oglematchers.Contains(expected[0]).Matches(actual); matchError != nil {
+		if fmt.Sprintf("%v", matchError) == "which is not a slice or array" {
+			return fmt.Sprintf(shouldHaveBeenAValidCollection, typeName)
+		}
+		return success
+	}
+	return fmt.Sprintf(shouldNotHaveContained, typeName, expected[0])
+}
+
+// ShouldContainKey receives exactly two parameters. The first is a map and the
+// second is a proposed key. Keys are compared with a simple '=='.
+func ShouldContainKey(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	keys, isMap := mapKeys(actual)
+	if !isMap {
+		return fmt.Sprintf(shouldHaveBeenAValidMap, reflect.TypeOf(actual))
+	}
+
+	if !keyFound(keys, expected[0]) {
+		return fmt.Sprintf(shouldHaveContainedKey, reflect.TypeOf(actual), expected)
+	}
+
+	return ""
+}
+
+// ShouldNotContainKey receives exactly two parameters. The first is a map and the
+// second is a proposed absent key. Keys are compared with a simple '=='.
+func ShouldNotContainKey(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	keys, isMap := mapKeys(actual)
+	if !isMap {
+		return fmt.Sprintf(shouldHaveBeenAValidMap, reflect.TypeOf(actual))
+	}
+
+	if keyFound(keys, expected[0]) {
+		return fmt.Sprintf(shouldNotHaveContainedKey, reflect.TypeOf(actual), expected)
+	}
+
+	return ""
+}
+
+func mapKeys(m interface{}) ([]reflect.Value, bool) {
+	value := reflect.ValueOf(m)
+	if value.Kind() != reflect.Map {
+		return nil, false
+	}
+	return value.MapKeys(), true
+}
+func keyFound(keys []reflect.Value, expectedKey interface{}) bool {
+	found := false
+	for _, key := range keys {
+		if key.Interface() == expectedKey {
+			found = true
+		}
+	}
+	return found
+}
+
+// ShouldBeIn receives at least 2 parameters. The first is a proposed member of the collection
+// that is passed in either as the second parameter, or of the collection that is comprised
+// of all the remaining parameters. This assertion ensures that the proposed member is in
+// the collection (using ShouldEqual).
+func ShouldBeIn(actual interface{}, expected ...interface{}) string {
+	if fail := atLeast(1, expected); fail != success {
+		return fail
+	}
+
+	if len(expected) == 1 {
+		return shouldBeIn(actual, expected[0])
+	}
+	return shouldBeIn(actual, expected)
+}
+func shouldBeIn(actual interface{}, expected interface{}) string {
+	if matchError := oglematchers.Contains(actual).Matches(expected); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenIn, actual, reflect.TypeOf(expected))
+	}
+	return success
+}
+
+// ShouldNotBeIn receives at least 2 parameters. The first is a proposed member of the collection
+// that is passed in either as the second parameter, or of the collection that is comprised
+// of all the remaining parameters. This assertion ensures that the proposed member is NOT in
+// the collection (using ShouldEqual).
+func ShouldNotBeIn(actual interface{}, expected ...interface{}) string {
+	if fail := atLeast(1, expected); fail != success {
+		return fail
+	}
+
+	if len(expected) == 1 {
+		return shouldNotBeIn(actual, expected[0])
+	}
+	return shouldNotBeIn(actual, expected)
+}
+func shouldNotBeIn(actual interface{}, expected interface{}) string {
+	if matchError := oglematchers.Contains(actual).Matches(expected); matchError == nil {
+		return fmt.Sprintf(shouldNotHaveBeenIn, actual, reflect.TypeOf(expected))
+	}
+	return success
+}
+
+// ShouldBeEmpty receives a single parameter (actual) and determines whether or not
+// calling len(actual) would return `0`. It obeys the rules specified by the len
+// function for determining length: http://golang.org/pkg/builtin/#len
+func ShouldBeEmpty(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	if actual == nil {
+		return success
+	}
+
+	value := reflect.ValueOf(actual)
+	switch value.Kind() {
+	case reflect.Slice:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.Chan:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.Map:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.String:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.Ptr:
+		elem := value.Elem()
+		kind := elem.Kind()
+		if (kind == reflect.Slice || kind == reflect.Array) && elem.Len() == 0 {
+			return success
+		}
+	}
+
+	return fmt.Sprintf(shouldHaveBeenEmpty, actual)
+}
+
+// ShouldNotBeEmpty receives a single parameter (actual) and determines whether or not
+// calling len(actual) would return a value greater than zero. It obeys the rules
+// specified by the `len` function for determining length: http://golang.org/pkg/builtin/#len
+func ShouldNotBeEmpty(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	if empty := ShouldBeEmpty(actual, expected...); empty != success {
+		return success
+	}
+	return fmt.Sprintf(shouldNotHaveBeenEmpty, actual)
+}
+
+// ShouldHaveLength receives 2 parameters. The first is a collection to check
+// the length of, the second being the expected length. It obeys the rules
+// specified by the len function for determining length:
+// http://golang.org/pkg/builtin/#len
+func ShouldHaveLength(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	var expectedLen int64
+	lenValue := reflect.ValueOf(expected[0])
+	switch lenValue.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		expectedLen = lenValue.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		expectedLen = int64(lenValue.Uint())
+	default:
+		return fmt.Sprintf(shouldHaveBeenAValidInteger, reflect.TypeOf(expected[0]))
+	}
+
+	if expectedLen < 0 {
+		return fmt.Sprintf(shouldHaveBeenAValidLength, expected[0])
+	}
+
+	value := reflect.ValueOf(actual)
+	switch value.Kind() {
+	case reflect.Slice,
+		reflect.Chan,
+		reflect.Map,
+		reflect.String:
+		if int64(value.Len()) == expectedLen {
+			return success
+		} else {
+			return fmt.Sprintf(shouldHaveHadLength, actual, value.Len(), expectedLen)
+		}
+	case reflect.Ptr:
+		elem := value.Elem()
+		kind := elem.Kind()
+		if kind == reflect.Slice || kind == reflect.Array {
+			if int64(elem.Len()) == expectedLen {
+				return success
+			} else {
+				return fmt.Sprintf(shouldHaveHadLength, actual, elem.Len(), expectedLen)
+			}
+		}
+	}
+	return fmt.Sprintf(shouldHaveBeenAValidCollection, reflect.TypeOf(actual))
+}

--- a/vendor/github.com/smartystreets/assertions/doc.go
+++ b/vendor/github.com/smartystreets/assertions/doc.go
@@ -1,0 +1,105 @@
+// Package assertions contains the implementations for all assertions which
+// are referenced in goconvey's `convey` package
+// (github.com/smartystreets/goconvey/convey) and gunit (github.com/smartystreets/gunit)
+// for use with the So(...) method.
+// They can also be used in traditional Go test functions and even in
+// applications.
+//
+// Many of the assertions lean heavily on work done by Aaron Jacobs in his excellent oglematchers library.
+// (https://github.com/jacobsa/oglematchers)
+// The ShouldResemble assertion leans heavily on work done by Daniel Jacques in his very helpful go-render library.
+// (https://github.com/luci/go-render)
+package assertions
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// By default we use a no-op serializer. The actual Serializer provides a JSON
+// representation of failure results on selected assertions so the goconvey
+// web UI can display a convenient diff.
+var serializer Serializer = new(noopSerializer)
+
+// GoConveyMode provides control over JSON serialization of failures. When
+// using the assertions in this package from the convey package JSON results
+// are very helpful and can be rendered in a DIFF view. In that case, this function
+// will be called with a true value to enable the JSON serialization. By default,
+// the assertions in this package will not serializer a JSON result, making
+// standalone ussage more convenient.
+func GoConveyMode(yes bool) {
+	if yes {
+		serializer = newSerializer()
+	} else {
+		serializer = new(noopSerializer)
+	}
+}
+
+type testingT interface {
+	Error(args ...interface{})
+}
+
+type Assertion struct {
+	t      testingT
+	failed bool
+}
+
+// New swallows the *testing.T struct and prints failed assertions using t.Error.
+// Example: assertions.New(t).So(1, should.Equal, 1)
+func New(t testingT) *Assertion {
+	return &Assertion{t: t}
+}
+
+// Failed reports whether any calls to So (on this Assertion instance) have failed.
+func (this *Assertion) Failed() bool {
+	return this.failed
+}
+
+// So calls the standalone So function and additionally, calls t.Error in failure scenarios.
+func (this *Assertion) So(actual interface{}, assert assertion, expected ...interface{}) bool {
+	ok, result := So(actual, assert, expected...)
+	if !ok {
+		this.failed = true
+		_, file, line, _ := runtime.Caller(1)
+		this.t.Error(fmt.Sprintf("\n%s:%d\n%s", file, line, result))
+	}
+	return ok
+}
+
+// So is a convenience function (as opposed to an inconvenience function?)
+// for running assertions on arbitrary arguments in any context, be it for testing or even
+// application logging. It allows you to perform assertion-like behavior (and get nicely
+// formatted messages detailing discrepancies) but without the program blowing up or panicking.
+// All that is required is to import this package and call `So` with one of the assertions
+// exported by this package as the second parameter.
+// The first return parameter is a boolean indicating if the assertion was true. The second
+// return parameter is the well-formatted message showing why an assertion was incorrect, or
+// blank if the assertion was correct.
+//
+// Example:
+//
+//   if ok, message := So(x, ShouldBeGreaterThan, y); !ok {
+//        log.Println(message)
+//   }
+//
+func So(actual interface{}, assert assertion, expected ...interface{}) (bool, string) {
+	if result := so(actual, assert, expected...); len(result) == 0 {
+		return true, result
+	} else {
+		return false, result
+	}
+}
+
+// so is like So, except that it only returns the string message, which is blank if the
+// assertion passed. Used to facilitate testing.
+func so(actual interface{}, assert func(interface{}, ...interface{}) string, expected ...interface{}) string {
+	return assert(actual, expected...)
+}
+
+// assertion is an alias for a function with a signature that the So()
+// function can handle. Any future or custom assertions should conform to this
+// method signature. The return value should be an empty string if the assertion
+// passes and a well-formed failure message if not.
+type assertion func(actual interface{}, expected ...interface{}) string
+
+////////////////////////////////////////////////////////////////////////////

--- a/vendor/github.com/smartystreets/assertions/equality.go
+++ b/vendor/github.com/smartystreets/assertions/equality.go
@@ -1,0 +1,280 @@
+package assertions
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+
+	"github.com/smartystreets/assertions/internal/oglematchers"
+	"github.com/smartystreets/assertions/internal/go-render/render"
+)
+
+// default acceptable delta for ShouldAlmostEqual
+const defaultDelta = 0.0000000001
+
+// ShouldEqual receives exactly two parameters and does an equality check.
+func ShouldEqual(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+	return shouldEqual(actual, expected[0])
+}
+func shouldEqual(actual, expected interface{}) (message string) {
+	defer func() {
+		if r := recover(); r != nil {
+			message = serializer.serialize(expected, actual, fmt.Sprintf(shouldHaveBeenEqual, expected, actual))
+			return
+		}
+	}()
+
+	if matchError := oglematchers.Equals(expected).Matches(actual); matchError != nil {
+		expectedSyntax := fmt.Sprintf("%v", expected)
+		actualSyntax := fmt.Sprintf("%v", actual)
+		if expectedSyntax == actualSyntax && reflect.TypeOf(expected) != reflect.TypeOf(actual) {
+			message = fmt.Sprintf(shouldHaveBeenEqualTypeMismatch, expected, expected, actual, actual)
+		} else {
+			message = fmt.Sprintf(shouldHaveBeenEqual, expected, actual)
+		}
+		message = serializer.serialize(expected, actual, message)
+		return
+	}
+
+	return success
+}
+
+// ShouldNotEqual receives exactly two parameters and does an inequality check.
+func ShouldNotEqual(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if ShouldEqual(actual, expected[0]) == success {
+		return fmt.Sprintf(shouldNotHaveBeenEqual, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldAlmostEqual makes sure that two parameters are close enough to being equal.
+// The acceptable delta may be specified with a third argument,
+// or a very small default delta will be used.
+func ShouldAlmostEqual(actual interface{}, expected ...interface{}) string {
+	actualFloat, expectedFloat, deltaFloat, err := cleanAlmostEqualInput(actual, expected...)
+
+	if err != "" {
+		return err
+	}
+
+	if math.Abs(actualFloat-expectedFloat) <= deltaFloat {
+		return success
+	} else {
+		return fmt.Sprintf(shouldHaveBeenAlmostEqual, actualFloat, expectedFloat)
+	}
+}
+
+// ShouldNotAlmostEqual is the inverse of ShouldAlmostEqual
+func ShouldNotAlmostEqual(actual interface{}, expected ...interface{}) string {
+	actualFloat, expectedFloat, deltaFloat, err := cleanAlmostEqualInput(actual, expected...)
+
+	if err != "" {
+		return err
+	}
+
+	if math.Abs(actualFloat-expectedFloat) > deltaFloat {
+		return success
+	} else {
+		return fmt.Sprintf(shouldHaveNotBeenAlmostEqual, actualFloat, expectedFloat)
+	}
+}
+
+func cleanAlmostEqualInput(actual interface{}, expected ...interface{}) (float64, float64, float64, string) {
+	deltaFloat := 0.0000000001
+
+	if len(expected) == 0 {
+		return 0.0, 0.0, 0.0, "This assertion requires exactly one comparison value and an optional delta (you provided neither)"
+	} else if len(expected) == 2 {
+		delta, err := getFloat(expected[1])
+
+		if err != nil {
+			return 0.0, 0.0, 0.0, "delta must be a numerical type"
+		}
+
+		deltaFloat = delta
+	} else if len(expected) > 2 {
+		return 0.0, 0.0, 0.0, "This assertion requires exactly one comparison value and an optional delta (you provided more values)"
+	}
+
+	actualFloat, err := getFloat(actual)
+
+	if err != nil {
+		return 0.0, 0.0, 0.0, err.Error()
+	}
+
+	expectedFloat, err := getFloat(expected[0])
+
+	if err != nil {
+		return 0.0, 0.0, 0.0, err.Error()
+	}
+
+	return actualFloat, expectedFloat, deltaFloat, ""
+}
+
+// returns the float value of any real number, or error if it is not a numerical type
+func getFloat(num interface{}) (float64, error) {
+	numValue := reflect.ValueOf(num)
+	numKind := numValue.Kind()
+
+	if numKind == reflect.Int ||
+		numKind == reflect.Int8 ||
+		numKind == reflect.Int16 ||
+		numKind == reflect.Int32 ||
+		numKind == reflect.Int64 {
+		return float64(numValue.Int()), nil
+	} else if numKind == reflect.Uint ||
+		numKind == reflect.Uint8 ||
+		numKind == reflect.Uint16 ||
+		numKind == reflect.Uint32 ||
+		numKind == reflect.Uint64 {
+		return float64(numValue.Uint()), nil
+	} else if numKind == reflect.Float32 ||
+		numKind == reflect.Float64 {
+		return numValue.Float(), nil
+	} else {
+		return 0.0, errors.New("must be a numerical type, but was " + numKind.String())
+	}
+}
+
+// ShouldResemble receives exactly two parameters and does a deep equal check (see reflect.DeepEqual)
+func ShouldResemble(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+
+	if matchError := oglematchers.DeepEquals(expected[0]).Matches(actual); matchError != nil {
+		return serializer.serializeDetailed(expected[0], actual,
+			fmt.Sprintf(shouldHaveResembled, render.Render(expected[0]), render.Render(actual)))
+	}
+
+	return success
+}
+
+// ShouldNotResemble receives exactly two parameters and does an inverse deep equal check (see reflect.DeepEqual)
+func ShouldNotResemble(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	} else if ShouldResemble(actual, expected[0]) == success {
+		return fmt.Sprintf(shouldNotHaveResembled, render.Render(actual), render.Render(expected[0]))
+	}
+	return success
+}
+
+// ShouldPointTo receives exactly two parameters and checks to see that they point to the same address.
+func ShouldPointTo(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+	return shouldPointTo(actual, expected[0])
+
+}
+func shouldPointTo(actual, expected interface{}) string {
+	actualValue := reflect.ValueOf(actual)
+	expectedValue := reflect.ValueOf(expected)
+
+	if ShouldNotBeNil(actual) != success {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "first", "nil")
+	} else if ShouldNotBeNil(expected) != success {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "second", "nil")
+	} else if actualValue.Kind() != reflect.Ptr {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "first", "not")
+	} else if expectedValue.Kind() != reflect.Ptr {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "second", "not")
+	} else if ShouldEqual(actualValue.Pointer(), expectedValue.Pointer()) != success {
+		actualAddress := reflect.ValueOf(actual).Pointer()
+		expectedAddress := reflect.ValueOf(expected).Pointer()
+		return serializer.serialize(expectedAddress, actualAddress, fmt.Sprintf(shouldHavePointedTo,
+			actual, actualAddress,
+			expected, expectedAddress))
+	}
+	return success
+}
+
+// ShouldNotPointTo receives exactly two parameters and checks to see that they point to different addresess.
+func ShouldNotPointTo(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+	compare := ShouldPointTo(actual, expected[0])
+	if strings.HasPrefix(compare, shouldBePointers) {
+		return compare
+	} else if compare == success {
+		return fmt.Sprintf(shouldNotHavePointedTo, actual, expected[0], reflect.ValueOf(actual).Pointer())
+	}
+	return success
+}
+
+// ShouldBeNil receives a single parameter and ensures that it is nil.
+func ShouldBeNil(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if actual == nil {
+		return success
+	} else if interfaceHasNilValue(actual) {
+		return success
+	}
+	return fmt.Sprintf(shouldHaveBeenNil, actual)
+}
+func interfaceHasNilValue(actual interface{}) bool {
+	value := reflect.ValueOf(actual)
+	kind := value.Kind()
+	nilable := kind == reflect.Slice ||
+		kind == reflect.Chan ||
+		kind == reflect.Func ||
+		kind == reflect.Ptr ||
+		kind == reflect.Map
+
+	// Careful: reflect.Value.IsNil() will panic unless it's an interface, chan, map, func, slice, or ptr
+	// Reference: http://golang.org/pkg/reflect/#Value.IsNil
+	return nilable && value.IsNil()
+}
+
+// ShouldNotBeNil receives a single parameter and ensures that it is not nil.
+func ShouldNotBeNil(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if ShouldBeNil(actual) == success {
+		return fmt.Sprintf(shouldNotHaveBeenNil, actual)
+	}
+	return success
+}
+
+// ShouldBeTrue receives a single parameter and ensures that it is true.
+func ShouldBeTrue(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if actual != true {
+		return fmt.Sprintf(shouldHaveBeenTrue, actual)
+	}
+	return success
+}
+
+// ShouldBeFalse receives a single parameter and ensures that it is false.
+func ShouldBeFalse(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if actual != false {
+		return fmt.Sprintf(shouldHaveBeenFalse, actual)
+	}
+	return success
+}
+
+// ShouldBeZeroValue receives a single parameter and ensures that it is
+// the Go equivalent of the default value, or "zero" value.
+func ShouldBeZeroValue(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+	zeroVal := reflect.Zero(reflect.TypeOf(actual)).Interface()
+	if !reflect.DeepEqual(zeroVal, actual) {
+		return serializer.serialize(zeroVal, actual, fmt.Sprintf(shouldHaveBeenZeroValue, actual))
+	}
+	return success
+}

--- a/vendor/github.com/smartystreets/assertions/filter.go
+++ b/vendor/github.com/smartystreets/assertions/filter.go
@@ -1,0 +1,23 @@
+package assertions
+
+import "fmt"
+
+const (
+	success                = ""
+	needExactValues        = "This assertion requires exactly %d comparison values (you provided %d)."
+	needNonEmptyCollection = "This assertion requires at least 1 comparison value (you provided 0)."
+)
+
+func need(needed int, expected []interface{}) string {
+	if len(expected) != needed {
+		return fmt.Sprintf(needExactValues, needed, len(expected))
+	}
+	return success
+}
+
+func atLeast(minimum int, expected []interface{}) string {
+	if len(expected) < 1 {
+		return needNonEmptyCollection
+	}
+	return success
+}

--- a/vendor/github.com/smartystreets/assertions/internal/go-render/render/render.go
+++ b/vendor/github.com/smartystreets/assertions/internal/go-render/render/render.go
@@ -1,0 +1,477 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package render
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+)
+
+var builtinTypeMap = map[reflect.Kind]string{
+	reflect.Bool:       "bool",
+	reflect.Complex128: "complex128",
+	reflect.Complex64:  "complex64",
+	reflect.Float32:    "float32",
+	reflect.Float64:    "float64",
+	reflect.Int16:      "int16",
+	reflect.Int32:      "int32",
+	reflect.Int64:      "int64",
+	reflect.Int8:       "int8",
+	reflect.Int:        "int",
+	reflect.String:     "string",
+	reflect.Uint16:     "uint16",
+	reflect.Uint32:     "uint32",
+	reflect.Uint64:     "uint64",
+	reflect.Uint8:      "uint8",
+	reflect.Uint:       "uint",
+	reflect.Uintptr:    "uintptr",
+}
+
+var builtinTypeSet = map[string]struct{}{}
+
+func init() {
+	for _, v := range builtinTypeMap {
+		builtinTypeSet[v] = struct{}{}
+	}
+}
+
+var typeOfString = reflect.TypeOf("")
+var typeOfInt = reflect.TypeOf(int(1))
+var typeOfUint = reflect.TypeOf(uint(1))
+var typeOfFloat = reflect.TypeOf(10.1)
+
+// Render converts a structure to a string representation. Unline the "%#v"
+// format string, this resolves pointer types' contents in structs, maps, and
+// slices/arrays and prints their field values.
+func Render(v interface{}) string {
+	buf := bytes.Buffer{}
+	s := (*traverseState)(nil)
+	s.render(&buf, 0, reflect.ValueOf(v), false)
+	return buf.String()
+}
+
+// renderPointer is called to render a pointer value.
+//
+// This is overridable so that the test suite can have deterministic pointer
+// values in its expectations.
+var renderPointer = func(buf *bytes.Buffer, p uintptr) {
+	fmt.Fprintf(buf, "0x%016x", p)
+}
+
+// traverseState is used to note and avoid recursion as struct members are being
+// traversed.
+//
+// traverseState is allowed to be nil. Specifically, the root state is nil.
+type traverseState struct {
+	parent *traverseState
+	ptr    uintptr
+}
+
+func (s *traverseState) forkFor(ptr uintptr) *traverseState {
+	for cur := s; cur != nil; cur = cur.parent {
+		if ptr == cur.ptr {
+			return nil
+		}
+	}
+
+	fs := &traverseState{
+		parent: s,
+		ptr:    ptr,
+	}
+	return fs
+}
+
+func (s *traverseState) render(buf *bytes.Buffer, ptrs int, v reflect.Value, implicit bool) {
+	if v.Kind() == reflect.Invalid {
+		buf.WriteString("nil")
+		return
+	}
+	vt := v.Type()
+
+	// If the type being rendered is a potentially recursive type (a type that
+	// can contain itself as a member), we need to avoid recursion.
+	//
+	// If we've already seen this type before, mark that this is the case and
+	// write a recursion placeholder instead of actually rendering it.
+	//
+	// If we haven't seen it before, fork our `seen` tracking so any higher-up
+	// renderers will also render it at least once, then mark that we've seen it
+	// to avoid recursing on lower layers.
+	pe := uintptr(0)
+	vk := vt.Kind()
+	switch vk {
+	case reflect.Ptr:
+		// Since structs and arrays aren't pointers, they can't directly be
+		// recursed, but they can contain pointers to themselves. Record their
+		// pointer to avoid this.
+		switch v.Elem().Kind() {
+		case reflect.Struct, reflect.Array:
+			pe = v.Pointer()
+		}
+
+	case reflect.Slice, reflect.Map:
+		pe = v.Pointer()
+	}
+	if pe != 0 {
+		s = s.forkFor(pe)
+		if s == nil {
+			buf.WriteString("<REC(")
+			if !implicit {
+				writeType(buf, ptrs, vt)
+			}
+			buf.WriteString(")>")
+			return
+		}
+	}
+
+	isAnon := func(t reflect.Type) bool {
+		if t.Name() != "" {
+			if _, ok := builtinTypeSet[t.Name()]; !ok {
+				return false
+			}
+		}
+		return t.Kind() != reflect.Interface
+	}
+
+	switch vk {
+	case reflect.Struct:
+		if !implicit {
+			writeType(buf, ptrs, vt)
+		}
+		structAnon := vt.Name() == ""
+		buf.WriteRune('{')
+		for i := 0; i < vt.NumField(); i++ {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			anon := structAnon && isAnon(vt.Field(i).Type)
+
+			if !anon {
+				buf.WriteString(vt.Field(i).Name)
+				buf.WriteRune(':')
+			}
+
+			s.render(buf, 0, v.Field(i), anon)
+		}
+		buf.WriteRune('}')
+
+	case reflect.Slice:
+		if v.IsNil() {
+			if !implicit {
+				writeType(buf, ptrs, vt)
+				buf.WriteString("(nil)")
+			} else {
+				buf.WriteString("nil")
+			}
+			return
+		}
+		fallthrough
+
+	case reflect.Array:
+		if !implicit {
+			writeType(buf, ptrs, vt)
+		}
+		anon := vt.Name() == "" && isAnon(vt.Elem())
+		buf.WriteString("{")
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+
+			s.render(buf, 0, v.Index(i), anon)
+		}
+		buf.WriteRune('}')
+
+	case reflect.Map:
+		if !implicit {
+			writeType(buf, ptrs, vt)
+		}
+		if v.IsNil() {
+			buf.WriteString("(nil)")
+		} else {
+			buf.WriteString("{")
+
+			mkeys := v.MapKeys()
+			tryAndSortMapKeys(vt, mkeys)
+
+			kt := vt.Key()
+			keyAnon := typeOfString.ConvertibleTo(kt) || typeOfInt.ConvertibleTo(kt) || typeOfUint.ConvertibleTo(kt) || typeOfFloat.ConvertibleTo(kt)
+			valAnon := vt.Name() == "" && isAnon(vt.Elem())
+			for i, mk := range mkeys {
+				if i > 0 {
+					buf.WriteString(", ")
+				}
+
+				s.render(buf, 0, mk, keyAnon)
+				buf.WriteString(":")
+				s.render(buf, 0, v.MapIndex(mk), valAnon)
+			}
+			buf.WriteRune('}')
+		}
+
+	case reflect.Ptr:
+		ptrs++
+		fallthrough
+	case reflect.Interface:
+		if v.IsNil() {
+			writeType(buf, ptrs, v.Type())
+			buf.WriteString("(nil)")
+		} else {
+			s.render(buf, ptrs, v.Elem(), false)
+		}
+
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		writeType(buf, ptrs, vt)
+		buf.WriteRune('(')
+		renderPointer(buf, v.Pointer())
+		buf.WriteRune(')')
+
+	default:
+		tstr := vt.String()
+		implicit = implicit || (ptrs == 0 && builtinTypeMap[vk] == tstr)
+		if !implicit {
+			writeType(buf, ptrs, vt)
+			buf.WriteRune('(')
+		}
+
+		switch vk {
+		case reflect.String:
+			fmt.Fprintf(buf, "%q", v.String())
+		case reflect.Bool:
+			fmt.Fprintf(buf, "%v", v.Bool())
+
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			fmt.Fprintf(buf, "%d", v.Int())
+
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			fmt.Fprintf(buf, "%d", v.Uint())
+
+		case reflect.Float32, reflect.Float64:
+			fmt.Fprintf(buf, "%g", v.Float())
+
+		case reflect.Complex64, reflect.Complex128:
+			fmt.Fprintf(buf, "%g", v.Complex())
+		}
+
+		if !implicit {
+			buf.WriteRune(')')
+		}
+	}
+}
+
+func writeType(buf *bytes.Buffer, ptrs int, t reflect.Type) {
+	parens := ptrs > 0
+	switch t.Kind() {
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		parens = true
+	}
+
+	if parens {
+		buf.WriteRune('(')
+		for i := 0; i < ptrs; i++ {
+			buf.WriteRune('*')
+		}
+	}
+
+	switch t.Kind() {
+	case reflect.Ptr:
+		if ptrs == 0 {
+			// This pointer was referenced from within writeType (e.g., as part of
+			// rendering a list), and so hasn't had its pointer asterisk accounted
+			// for.
+			buf.WriteRune('*')
+		}
+		writeType(buf, 0, t.Elem())
+
+	case reflect.Interface:
+		if n := t.Name(); n != "" {
+			buf.WriteString(t.String())
+		} else {
+			buf.WriteString("interface{}")
+		}
+
+	case reflect.Array:
+		buf.WriteRune('[')
+		buf.WriteString(strconv.FormatInt(int64(t.Len()), 10))
+		buf.WriteRune(']')
+		writeType(buf, 0, t.Elem())
+
+	case reflect.Slice:
+		if t == reflect.SliceOf(t.Elem()) {
+			buf.WriteString("[]")
+			writeType(buf, 0, t.Elem())
+		} else {
+			// Custom slice type, use type name.
+			buf.WriteString(t.String())
+		}
+
+	case reflect.Map:
+		if t == reflect.MapOf(t.Key(), t.Elem()) {
+			buf.WriteString("map[")
+			writeType(buf, 0, t.Key())
+			buf.WriteRune(']')
+			writeType(buf, 0, t.Elem())
+		} else {
+			// Custom map type, use type name.
+			buf.WriteString(t.String())
+		}
+
+	default:
+		buf.WriteString(t.String())
+	}
+
+	if parens {
+		buf.WriteRune(')')
+	}
+}
+
+type cmpFn func(a, b reflect.Value) int
+
+type sortableValueSlice struct {
+	cmp      cmpFn
+	elements []reflect.Value
+}
+
+func (s sortableValueSlice) Len() int {
+	return len(s.elements)
+}
+
+func (s sortableValueSlice) Less(i, j int) bool {
+	return s.cmp(s.elements[i], s.elements[j]) < 0
+}
+
+func (s sortableValueSlice) Swap(i, j int) {
+	s.elements[i], s.elements[j] = s.elements[j], s.elements[i]
+}
+
+// cmpForType returns a cmpFn which sorts the data for some type t in the same
+// order that a go-native map key is compared for equality.
+func cmpForType(t reflect.Type) cmpFn {
+	switch t.Kind() {
+	case reflect.String:
+		return func(av, bv reflect.Value) int {
+			a, b := av.String(), bv.String()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Bool:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Bool(), bv.Bool()
+			if !a && b {
+				return -1
+			} else if a && !b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Int(), bv.Int()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+		reflect.Uint64, reflect.Uintptr, reflect.UnsafePointer:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Uint(), bv.Uint()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Float32, reflect.Float64:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Float(), bv.Float()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Interface:
+		return func(av, bv reflect.Value) int {
+			a, b := av.InterfaceData(), bv.InterfaceData()
+			if a[0] < b[0] {
+				return -1
+			} else if a[0] > b[0] {
+				return 1
+			}
+			if a[1] < b[1] {
+				return -1
+			} else if a[1] > b[1] {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Complex64, reflect.Complex128:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Complex(), bv.Complex()
+			if real(a) < real(b) {
+				return -1
+			} else if real(a) > real(b) {
+				return 1
+			}
+			if imag(a) < imag(b) {
+				return -1
+			} else if imag(a) > imag(b) {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Ptr, reflect.Chan:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Pointer(), bv.Pointer()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Struct:
+		cmpLst := make([]cmpFn, t.NumField())
+		for i := range cmpLst {
+			cmpLst[i] = cmpForType(t.Field(i).Type)
+		}
+		return func(a, b reflect.Value) int {
+			for i, cmp := range cmpLst {
+				if rslt := cmp(a.Field(i), b.Field(i)); rslt != 0 {
+					return rslt
+				}
+			}
+			return 0
+		}
+	}
+
+	return nil
+}
+
+func tryAndSortMapKeys(mt reflect.Type, k []reflect.Value) {
+	if cmp := cmpForType(mt.Key()); cmp != nil {
+		sort.Sort(sortableValueSlice{cmp, k})
+	}
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/all_of.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/all_of.go
@@ -1,0 +1,70 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"strings"
+)
+
+// AllOf accepts a set of matchers S and returns a matcher that follows the
+// algorithm below when considering a candidate c:
+//
+//  1. Return true if for every Matcher m in S, m matches c.
+//
+//  2. Otherwise, if there is a matcher m in S such that m returns a fatal
+//     error for c, return that matcher's error message.
+//
+//  3. Otherwise, return false with the error from some wrapped matcher.
+//
+// This is akin to a logical AND operation for matchers.
+func AllOf(matchers ...Matcher) Matcher {
+	return &allOfMatcher{matchers}
+}
+
+type allOfMatcher struct {
+	wrappedMatchers []Matcher
+}
+
+func (m *allOfMatcher) Description() string {
+	// Special case: the empty set.
+	if len(m.wrappedMatchers) == 0 {
+		return "is anything"
+	}
+
+	// Join the descriptions for the wrapped matchers.
+	wrappedDescs := make([]string, len(m.wrappedMatchers))
+	for i, wrappedMatcher := range m.wrappedMatchers {
+		wrappedDescs[i] = wrappedMatcher.Description()
+	}
+
+	return strings.Join(wrappedDescs, ", and ")
+}
+
+func (m *allOfMatcher) Matches(c interface{}) (err error) {
+	for _, wrappedMatcher := range m.wrappedMatchers {
+		if wrappedErr := wrappedMatcher.Matches(c); wrappedErr != nil {
+			err = wrappedErr
+
+			// If the error is fatal, return immediately with this error.
+			_, ok := wrappedErr.(*FatalError)
+			if ok {
+				return
+			}
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/any.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/any.go
@@ -1,0 +1,32 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+// Any returns a matcher that matches any value.
+func Any() Matcher {
+	return &anyMatcher{}
+}
+
+type anyMatcher struct {
+}
+
+func (m *anyMatcher) Description() string {
+	return "is anything"
+}
+
+func (m *anyMatcher) Matches(c interface{}) error {
+	return nil
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/any_of.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/any_of.go
@@ -1,0 +1,94 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// AnyOf accepts a set of values S and returns a matcher that follows the
+// algorithm below when considering a candidate c:
+//
+//  1. If there exists a value m in S such that m implements the Matcher
+//     interface and m matches c, return true.
+//
+//  2. Otherwise, if there exists a value v in S such that v does not implement
+//     the Matcher interface and the matcher Equals(v) matches c, return true.
+//
+//  3. Otherwise, if there is a value m in S such that m implements the Matcher
+//     interface and m returns a fatal error for c, return that fatal error.
+//
+//  4. Otherwise, return false.
+//
+// This is akin to a logical OR operation for matchers, with non-matchers x
+// being treated as Equals(x).
+func AnyOf(vals ...interface{}) Matcher {
+	// Get ahold of a type variable for the Matcher interface.
+	var dummy *Matcher
+	matcherType := reflect.TypeOf(dummy).Elem()
+
+	// Create a matcher for each value, or use the value itself if it's already a
+	// matcher.
+	wrapped := make([]Matcher, len(vals))
+	for i, v := range vals {
+		t := reflect.TypeOf(v)
+		if t != nil && t.Implements(matcherType) {
+			wrapped[i] = v.(Matcher)
+		} else {
+			wrapped[i] = Equals(v)
+		}
+	}
+
+	return &anyOfMatcher{wrapped}
+}
+
+type anyOfMatcher struct {
+	wrapped []Matcher
+}
+
+func (m *anyOfMatcher) Description() string {
+	wrappedDescs := make([]string, len(m.wrapped))
+	for i, matcher := range m.wrapped {
+		wrappedDescs[i] = matcher.Description()
+	}
+
+	return fmt.Sprintf("or(%s)", strings.Join(wrappedDescs, ", "))
+}
+
+func (m *anyOfMatcher) Matches(c interface{}) (err error) {
+	err = errors.New("")
+
+	// Try each matcher in turn.
+	for _, matcher := range m.wrapped {
+		wrappedErr := matcher.Matches(c)
+
+		// Return immediately if there's a match.
+		if wrappedErr == nil {
+			err = nil
+			return
+		}
+
+		// Note the fatal error, if any.
+		if _, isFatal := wrappedErr.(*FatalError); isFatal {
+			err = wrappedErr
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/contains.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/contains.go
@@ -1,0 +1,61 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Return a matcher that matches arrays slices with at least one element that
+// matches the supplied argument. If the argument x is not itself a Matcher,
+// this is equivalent to Contains(Equals(x)).
+func Contains(x interface{}) Matcher {
+	var result containsMatcher
+	var ok bool
+
+	if result.elementMatcher, ok = x.(Matcher); !ok {
+		result.elementMatcher = DeepEquals(x)
+	}
+
+	return &result
+}
+
+type containsMatcher struct {
+	elementMatcher Matcher
+}
+
+func (m *containsMatcher) Description() string {
+	return fmt.Sprintf("contains: %s", m.elementMatcher.Description())
+}
+
+func (m *containsMatcher) Matches(candidate interface{}) error {
+	// The candidate must be a slice or an array.
+	v := reflect.ValueOf(candidate)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return NewFatalError("which is not a slice or array")
+	}
+
+	// Check each element.
+	for i := 0; i < v.Len(); i++ {
+		elem := v.Index(i)
+		if matchErr := m.elementMatcher.Matches(elem.Interface()); matchErr == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/deep_equals.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/deep_equals.go
@@ -1,0 +1,88 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+var byteSliceType reflect.Type = reflect.TypeOf([]byte{})
+
+// DeepEquals returns a matcher that matches based on 'deep equality', as
+// defined by the reflect package. This matcher requires that values have
+// identical types to x.
+func DeepEquals(x interface{}) Matcher {
+	return &deepEqualsMatcher{x}
+}
+
+type deepEqualsMatcher struct {
+	x interface{}
+}
+
+func (m *deepEqualsMatcher) Description() string {
+	xDesc := fmt.Sprintf("%v", m.x)
+	xValue := reflect.ValueOf(m.x)
+
+	// Special case: fmt.Sprintf presents nil slices as "[]", but
+	// reflect.DeepEqual makes a distinction between nil and empty slices. Make
+	// this less confusing.
+	if xValue.Kind() == reflect.Slice && xValue.IsNil() {
+		xDesc = "<nil slice>"
+	}
+
+	return fmt.Sprintf("deep equals: %s", xDesc)
+}
+
+func (m *deepEqualsMatcher) Matches(c interface{}) error {
+	// Make sure the types match.
+	ct := reflect.TypeOf(c)
+	xt := reflect.TypeOf(m.x)
+
+	if ct != xt {
+		return NewFatalError(fmt.Sprintf("which is of type %v", ct))
+	}
+
+	// Special case: handle byte slices more efficiently.
+	cValue := reflect.ValueOf(c)
+	xValue := reflect.ValueOf(m.x)
+
+	if ct == byteSliceType && !cValue.IsNil() && !xValue.IsNil() {
+		xBytes := m.x.([]byte)
+		cBytes := c.([]byte)
+
+		if bytes.Equal(cBytes, xBytes) {
+			return nil
+		}
+
+		return errors.New("")
+	}
+
+	// Defer to the reflect package.
+	if reflect.DeepEqual(m.x, c) {
+		return nil
+	}
+
+	// Special case: if the comparison failed because c is the nil slice, given
+	// an indication of this (since its value is printed as "[]").
+	if cValue.Kind() == reflect.Slice && cValue.IsNil() {
+		return errors.New("which is nil")
+	}
+
+	return errors.New("")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/elements_are.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/elements_are.go
@@ -1,0 +1,91 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Given a list of arguments M, ElementsAre returns a matcher that matches
+// arrays and slices A where all of the following hold:
+//
+//  *  A is the same length as M.
+//
+//  *  For each i < len(A) where M[i] is a matcher, A[i] matches M[i].
+//
+//  *  For each i < len(A) where M[i] is not a matcher, A[i] matches
+//     Equals(M[i]).
+//
+func ElementsAre(M ...interface{}) Matcher {
+	// Copy over matchers, or convert to Equals(x) for non-matcher x.
+	subMatchers := make([]Matcher, len(M))
+	for i, x := range M {
+		if matcher, ok := x.(Matcher); ok {
+			subMatchers[i] = matcher
+			continue
+		}
+
+		subMatchers[i] = Equals(x)
+	}
+
+	return &elementsAreMatcher{subMatchers}
+}
+
+type elementsAreMatcher struct {
+	subMatchers []Matcher
+}
+
+func (m *elementsAreMatcher) Description() string {
+	subDescs := make([]string, len(m.subMatchers))
+	for i, sm := range m.subMatchers {
+		subDescs[i] = sm.Description()
+	}
+
+	return fmt.Sprintf("elements are: [%s]", strings.Join(subDescs, ", "))
+}
+
+func (m *elementsAreMatcher) Matches(candidates interface{}) error {
+	// The candidate must be a slice or an array.
+	v := reflect.ValueOf(candidates)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return NewFatalError("which is not a slice or array")
+	}
+
+	// The length must be correct.
+	if v.Len() != len(m.subMatchers) {
+		return errors.New(fmt.Sprintf("which is of length %d", v.Len()))
+	}
+
+	// Check each element.
+	for i, subMatcher := range m.subMatchers {
+		c := v.Index(i)
+		if matchErr := subMatcher.Matches(c.Interface()); matchErr != nil {
+			// Return an errors indicating which element doesn't match. If the
+			// matcher error was fatal, make this one fatal too.
+			err := errors.New(fmt.Sprintf("whose element %d doesn't match", i))
+			if _, isFatal := matchErr.(*FatalError); isFatal {
+				err = NewFatalError(err.Error())
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/equals.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/equals.go
@@ -1,0 +1,541 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+// Equals(x) returns a matcher that matches values v such that v and x are
+// equivalent. This includes the case when the comparison v == x using Go's
+// built-in comparison operator is legal (except for structs, which this
+// matcher does not support), but for convenience the following rules also
+// apply:
+//
+//  *  Type checking is done based on underlying types rather than actual
+//     types, so that e.g. two aliases for string can be compared:
+//
+//         type stringAlias1 string
+//         type stringAlias2 string
+//
+//         a := "taco"
+//         b := stringAlias1("taco")
+//         c := stringAlias2("taco")
+//
+//         ExpectTrue(a == b)  // Legal, passes
+//         ExpectTrue(b == c)  // Illegal, doesn't compile
+//
+//         ExpectThat(a, Equals(b))  // Passes
+//         ExpectThat(b, Equals(c))  // Passes
+//
+//  *  Values of numeric type are treated as if they were abstract numbers, and
+//     compared accordingly. Therefore Equals(17) will match int(17),
+//     int16(17), uint(17), float32(17), complex64(17), and so on.
+//
+// If you want a stricter matcher that contains no such cleverness, see
+// IdenticalTo instead.
+//
+// Arrays are supported by this matcher, but do not participate in the
+// exceptions above. Two arrays compared with this matcher must have identical
+// types, and their element type must itself be comparable according to Go's ==
+// operator.
+func Equals(x interface{}) Matcher {
+	v := reflect.ValueOf(x)
+
+	// This matcher doesn't support structs.
+	if v.Kind() == reflect.Struct {
+		panic(fmt.Sprintf("oglematchers.Equals: unsupported kind %v", v.Kind()))
+	}
+
+	// The == operator is not defined for non-nil slices.
+	if v.Kind() == reflect.Slice && v.Pointer() != uintptr(0) {
+		panic(fmt.Sprintf("oglematchers.Equals: non-nil slice"))
+	}
+
+	return &equalsMatcher{v}
+}
+
+type equalsMatcher struct {
+	expectedValue reflect.Value
+}
+
+////////////////////////////////////////////////////////////////////////
+// Numeric types
+////////////////////////////////////////////////////////////////////////
+
+func isSignedInteger(v reflect.Value) bool {
+	k := v.Kind()
+	return k >= reflect.Int && k <= reflect.Int64
+}
+
+func isUnsignedInteger(v reflect.Value) bool {
+	k := v.Kind()
+	return k >= reflect.Uint && k <= reflect.Uintptr
+}
+
+func isInteger(v reflect.Value) bool {
+	return isSignedInteger(v) || isUnsignedInteger(v)
+}
+
+func isFloat(v reflect.Value) bool {
+	k := v.Kind()
+	return k == reflect.Float32 || k == reflect.Float64
+}
+
+func isComplex(v reflect.Value) bool {
+	k := v.Kind()
+	return k == reflect.Complex64 || k == reflect.Complex128
+}
+
+func checkAgainstInt64(e int64, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(c):
+		if c.Int() == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		u := c.Uint()
+		if u <= math.MaxInt64 && int64(u) == e {
+			err = nil
+		}
+
+	// Turn around the various floating point types so that the checkAgainst*
+	// functions for them can deal with precision issues.
+	case isFloat(c), isComplex(c):
+		return Equals(c.Interface()).Matches(e)
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstUint64(e uint64, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(c):
+		i := c.Int()
+		if i >= 0 && uint64(i) == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		if c.Uint() == e {
+			err = nil
+		}
+
+	// Turn around the various floating point types so that the checkAgainst*
+	// functions for them can deal with precision issues.
+	case isFloat(c), isComplex(c):
+		return Equals(c.Interface()).Matches(e)
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstFloat32(e float32, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(c):
+		if float32(c.Int()) == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		if float32(c.Uint()) == e {
+			err = nil
+		}
+
+	case isFloat(c):
+		// Compare using float32 to avoid a false sense of precision; otherwise
+		// e.g. Equals(float32(0.1)) won't match float32(0.1).
+		if float32(c.Float()) == e {
+			err = nil
+		}
+
+	case isComplex(c):
+		comp := c.Complex()
+		rl := real(comp)
+		im := imag(comp)
+
+		// Compare using float32 to avoid a false sense of precision; otherwise
+		// e.g. Equals(float32(0.1)) won't match (0.1 + 0i).
+		if im == 0 && float32(rl) == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstFloat64(e float64, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	ck := c.Kind()
+
+	switch {
+	case isSignedInteger(c):
+		if float64(c.Int()) == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		if float64(c.Uint()) == e {
+			err = nil
+		}
+
+	// If the actual value is lower precision, turn the comparison around so we
+	// apply the low-precision rules. Otherwise, e.g. Equals(0.1) may not match
+	// float32(0.1).
+	case ck == reflect.Float32 || ck == reflect.Complex64:
+		return Equals(c.Interface()).Matches(e)
+
+		// Otherwise, compare with double precision.
+	case isFloat(c):
+		if c.Float() == e {
+			err = nil
+		}
+
+	case isComplex(c):
+		comp := c.Complex()
+		rl := real(comp)
+		im := imag(comp)
+
+		if im == 0 && rl == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstComplex64(e complex64, c reflect.Value) (err error) {
+	err = errors.New("")
+	realPart := real(e)
+	imaginaryPart := imag(e)
+
+	switch {
+	case isInteger(c) || isFloat(c):
+		// If we have no imaginary part, then we should just compare against the
+		// real part. Otherwise, we can't be equal.
+		if imaginaryPart != 0 {
+			return
+		}
+
+		return checkAgainstFloat32(realPart, c)
+
+	case isComplex(c):
+		// Compare using complex64 to avoid a false sense of precision; otherwise
+		// e.g. Equals(0.1 + 0i) won't match float32(0.1).
+		if complex64(c.Complex()) == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstComplex128(e complex128, c reflect.Value) (err error) {
+	err = errors.New("")
+	realPart := real(e)
+	imaginaryPart := imag(e)
+
+	switch {
+	case isInteger(c) || isFloat(c):
+		// If we have no imaginary part, then we should just compare against the
+		// real part. Otherwise, we can't be equal.
+		if imaginaryPart != 0 {
+			return
+		}
+
+		return checkAgainstFloat64(realPart, c)
+
+	case isComplex(c):
+		if c.Complex() == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+////////////////////////////////////////////////////////////////////////
+// Other types
+////////////////////////////////////////////////////////////////////////
+
+func checkAgainstBool(e bool, c reflect.Value) (err error) {
+	if c.Kind() != reflect.Bool {
+		err = NewFatalError("which is not a bool")
+		return
+	}
+
+	err = errors.New("")
+	if c.Bool() == e {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstChan(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "chan int".
+	typeStr := fmt.Sprintf("%s %s", e.Type().ChanDir(), e.Type().Elem())
+
+	// Make sure c is a chan of the correct type.
+	if c.Kind() != reflect.Chan ||
+		c.Type().ChanDir() != e.Type().ChanDir() ||
+		c.Type().Elem() != e.Type().Elem() {
+		err = NewFatalError(fmt.Sprintf("which is not a %s", typeStr))
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstFunc(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a function.
+	if c.Kind() != reflect.Func {
+		err = NewFatalError("which is not a function")
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstMap(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a map.
+	if c.Kind() != reflect.Map {
+		err = NewFatalError("which is not a map")
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstPtr(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "*int".
+	typeStr := fmt.Sprintf("*%v", e.Type().Elem())
+
+	// Make sure c is a pointer of the correct type.
+	if c.Kind() != reflect.Ptr ||
+		c.Type().Elem() != e.Type().Elem() {
+		err = NewFatalError(fmt.Sprintf("which is not a %s", typeStr))
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstSlice(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "[]int".
+	typeStr := fmt.Sprintf("[]%v", e.Type().Elem())
+
+	// Make sure c is a slice of the correct type.
+	if c.Kind() != reflect.Slice ||
+		c.Type().Elem() != e.Type().Elem() {
+		err = NewFatalError(fmt.Sprintf("which is not a %s", typeStr))
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstString(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a string.
+	if c.Kind() != reflect.String {
+		err = NewFatalError("which is not a string")
+		return
+	}
+
+	err = errors.New("")
+	if c.String() == e.String() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstArray(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "[2]int".
+	typeStr := fmt.Sprintf("%v", e.Type())
+
+	// Make sure c is the correct type.
+	if c.Type() != e.Type() {
+		err = NewFatalError(fmt.Sprintf("which is not %s", typeStr))
+		return
+	}
+
+	// Check for equality.
+	if e.Interface() != c.Interface() {
+		err = errors.New("")
+		return
+	}
+
+	return
+}
+
+func checkAgainstUnsafePointer(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a pointer.
+	if c.Kind() != reflect.UnsafePointer {
+		err = NewFatalError("which is not a unsafe.Pointer")
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkForNil(c reflect.Value) (err error) {
+	err = errors.New("")
+
+	// Make sure it is legal to call IsNil.
+	switch c.Kind() {
+	case reflect.Invalid:
+	case reflect.Chan:
+	case reflect.Func:
+	case reflect.Interface:
+	case reflect.Map:
+	case reflect.Ptr:
+	case reflect.Slice:
+
+	default:
+		err = NewFatalError("which cannot be compared to nil")
+		return
+	}
+
+	// Ask whether the value is nil. Handle a nil literal (kind Invalid)
+	// specially, since it's not legal to call IsNil there.
+	if c.Kind() == reflect.Invalid || c.IsNil() {
+		err = nil
+	}
+	return
+}
+
+////////////////////////////////////////////////////////////////////////
+// Public implementation
+////////////////////////////////////////////////////////////////////////
+
+func (m *equalsMatcher) Matches(candidate interface{}) error {
+	e := m.expectedValue
+	c := reflect.ValueOf(candidate)
+	ek := e.Kind()
+
+	switch {
+	case ek == reflect.Bool:
+		return checkAgainstBool(e.Bool(), c)
+
+	case isSignedInteger(e):
+		return checkAgainstInt64(e.Int(), c)
+
+	case isUnsignedInteger(e):
+		return checkAgainstUint64(e.Uint(), c)
+
+	case ek == reflect.Float32:
+		return checkAgainstFloat32(float32(e.Float()), c)
+
+	case ek == reflect.Float64:
+		return checkAgainstFloat64(e.Float(), c)
+
+	case ek == reflect.Complex64:
+		return checkAgainstComplex64(complex64(e.Complex()), c)
+
+	case ek == reflect.Complex128:
+		return checkAgainstComplex128(complex128(e.Complex()), c)
+
+	case ek == reflect.Chan:
+		return checkAgainstChan(e, c)
+
+	case ek == reflect.Func:
+		return checkAgainstFunc(e, c)
+
+	case ek == reflect.Map:
+		return checkAgainstMap(e, c)
+
+	case ek == reflect.Ptr:
+		return checkAgainstPtr(e, c)
+
+	case ek == reflect.Slice:
+		return checkAgainstSlice(e, c)
+
+	case ek == reflect.String:
+		return checkAgainstString(e, c)
+
+	case ek == reflect.Array:
+		return checkAgainstArray(e, c)
+
+	case ek == reflect.UnsafePointer:
+		return checkAgainstUnsafePointer(e, c)
+
+	case ek == reflect.Invalid:
+		return checkForNil(c)
+	}
+
+	panic(fmt.Sprintf("equalsMatcher.Matches: unexpected kind: %v", ek))
+}
+
+func (m *equalsMatcher) Description() string {
+	// Special case: handle nil.
+	if !m.expectedValue.IsValid() {
+		return "is nil"
+	}
+
+	return fmt.Sprintf("%v", m.expectedValue.Interface())
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/error.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/error.go
@@ -1,0 +1,51 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+// Error returns a matcher that matches non-nil values implementing the
+// built-in error interface for whom the return value of Error() matches the
+// supplied matcher.
+//
+// For example:
+//
+//     err := errors.New("taco burrito")
+//
+//     Error(Equals("taco burrito"))  // matches err
+//     Error(HasSubstr("taco"))       // matches err
+//     Error(HasSubstr("enchilada"))  // doesn't match err
+//
+func Error(m Matcher) Matcher {
+	return &errorMatcher{m}
+}
+
+type errorMatcher struct {
+	wrappedMatcher Matcher
+}
+
+func (m *errorMatcher) Description() string {
+	return "error " + m.wrappedMatcher.Description()
+}
+
+func (m *errorMatcher) Matches(c interface{}) error {
+	// Make sure that c is an error.
+	e, ok := c.(error)
+	if !ok {
+		return NewFatalError("which is not an error")
+	}
+
+	// Pass on the error text to the wrapped matcher.
+	return m.wrappedMatcher.Matches(e.Error())
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_or_equal.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_or_equal.go
@@ -1,0 +1,39 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// GreaterOrEqual returns a matcher that matches integer, floating point, or
+// strings values v such that v >= x. Comparison is not defined between numeric
+// and string types, but is defined between all integer and floating point
+// types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// GreaterOrEqual will panic.
+func GreaterOrEqual(x interface{}) Matcher {
+	desc := fmt.Sprintf("greater than or equal to %v", x)
+
+	// Special case: make it clear that strings are strings.
+	if reflect.TypeOf(x).Kind() == reflect.String {
+		desc = fmt.Sprintf("greater than or equal to \"%s\"", x)
+	}
+
+	return transformDescription(Not(LessThan(x)), desc)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_than.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_than.go
@@ -1,0 +1,39 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// GreaterThan returns a matcher that matches integer, floating point, or
+// strings values v such that v > x. Comparison is not defined between numeric
+// and string types, but is defined between all integer and floating point
+// types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// GreaterThan will panic.
+func GreaterThan(x interface{}) Matcher {
+	desc := fmt.Sprintf("greater than %v", x)
+
+	// Special case: make it clear that strings are strings.
+	if reflect.TypeOf(x).Kind() == reflect.String {
+		desc = fmt.Sprintf("greater than \"%s\"", x)
+	}
+
+	return transformDescription(Not(LessOrEqual(x)), desc)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/has_same_type_as.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/has_same_type_as.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// HasSameTypeAs returns a matcher that matches values with exactly the same
+// type as the supplied prototype.
+func HasSameTypeAs(p interface{}) Matcher {
+	expected := reflect.TypeOf(p)
+	pred := func(c interface{}) error {
+		actual := reflect.TypeOf(c)
+		if actual != expected {
+			return fmt.Errorf("which has type %v", actual)
+		}
+
+		return nil
+	}
+
+	return NewMatcher(pred, fmt.Sprintf("has type %v", expected))
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/has_substr.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/has_substr.go
@@ -1,0 +1,46 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// HasSubstr returns a matcher that matches strings containing s as a
+// substring.
+func HasSubstr(s string) Matcher {
+	return NewMatcher(
+		func(c interface{}) error { return hasSubstr(s, c) },
+		fmt.Sprintf("has substring \"%s\"", s))
+}
+
+func hasSubstr(needle string, c interface{}) error {
+	v := reflect.ValueOf(c)
+	if v.Kind() != reflect.String {
+		return NewFatalError("which is not a string")
+	}
+
+	// Perform the substring search.
+	haystack := v.String()
+	if strings.Contains(haystack, needle) {
+		return nil
+	}
+
+	return errors.New("")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/identical_to.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/identical_to.go
@@ -1,0 +1,134 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Is the type comparable according to the definition here?
+//
+//     http://weekly.golang.org/doc/go_spec.html#Comparison_operators
+//
+func isComparable(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Array:
+		return isComparable(t.Elem())
+
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if !isComparable(t.Field(i).Type) {
+				return false
+			}
+		}
+
+		return true
+
+	case reflect.Slice, reflect.Map, reflect.Func:
+		return false
+	}
+
+	return true
+}
+
+// Should the supplied type be allowed as an argument to IdenticalTo?
+func isLegalForIdenticalTo(t reflect.Type) (bool, error) {
+	// Allow the zero type.
+	if t == nil {
+		return true, nil
+	}
+
+	// Reference types are always okay; we compare pointers.
+	switch t.Kind() {
+	case reflect.Slice, reflect.Map, reflect.Func, reflect.Chan:
+		return true, nil
+	}
+
+	// Reject other non-comparable types.
+	if !isComparable(t) {
+		return false, errors.New(fmt.Sprintf("%v is not comparable", t))
+	}
+
+	return true, nil
+}
+
+// IdenticalTo(x) returns a matcher that matches values v with type identical
+// to x such that:
+//
+//  1. If v and x are of a reference type (slice, map, function, channel), then
+//     they are either both nil or are references to the same object.
+//
+//  2. Otherwise, if v and x are not of a reference type but have a valid type,
+//     then v == x.
+//
+// If v and x are both the invalid type (which results from the predeclared nil
+// value, or from nil interface variables), then the matcher is satisfied.
+//
+// This function will panic if x is of a value type that is not comparable. For
+// example, x cannot be an array of functions.
+func IdenticalTo(x interface{}) Matcher {
+	t := reflect.TypeOf(x)
+
+	// Reject illegal arguments.
+	if ok, err := isLegalForIdenticalTo(t); !ok {
+		panic("IdenticalTo: " + err.Error())
+	}
+
+	return &identicalToMatcher{x}
+}
+
+type identicalToMatcher struct {
+	x interface{}
+}
+
+func (m *identicalToMatcher) Description() string {
+	t := reflect.TypeOf(m.x)
+	return fmt.Sprintf("identical to <%v> %v", t, m.x)
+}
+
+func (m *identicalToMatcher) Matches(c interface{}) error {
+	// Make sure the candidate's type is correct.
+	t := reflect.TypeOf(m.x)
+	if ct := reflect.TypeOf(c); t != ct {
+		return NewFatalError(fmt.Sprintf("which is of type %v", ct))
+	}
+
+	// Special case: two values of the invalid type are always identical.
+	if t == nil {
+		return nil
+	}
+
+	// Handle reference types.
+	switch t.Kind() {
+	case reflect.Slice, reflect.Map, reflect.Func, reflect.Chan:
+		xv := reflect.ValueOf(m.x)
+		cv := reflect.ValueOf(c)
+		if xv.Pointer() == cv.Pointer() {
+			return nil
+		}
+
+		return errors.New("which is not an identical reference")
+	}
+
+	// Are the values equal?
+	if m.x == c {
+		return nil
+	}
+
+	return errors.New("")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_or_equal.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_or_equal.go
@@ -1,0 +1,41 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// LessOrEqual returns a matcher that matches integer, floating point, or
+// strings values v such that v <= x. Comparison is not defined between numeric
+// and string types, but is defined between all integer and floating point
+// types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// LessOrEqual will panic.
+func LessOrEqual(x interface{}) Matcher {
+	desc := fmt.Sprintf("less than or equal to %v", x)
+
+	// Special case: make it clear that strings are strings.
+	if reflect.TypeOf(x).Kind() == reflect.String {
+		desc = fmt.Sprintf("less than or equal to \"%s\"", x)
+	}
+
+	// Put LessThan last so that its error messages will be used in the event of
+	// failure.
+	return transformDescription(AnyOf(Equals(x), LessThan(x)), desc)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_than.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_than.go
@@ -1,0 +1,152 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+// LessThan returns a matcher that matches integer, floating point, or strings
+// values v such that v < x. Comparison is not defined between numeric and
+// string types, but is defined between all integer and floating point types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// LessThan will panic.
+func LessThan(x interface{}) Matcher {
+	v := reflect.ValueOf(x)
+	kind := v.Kind()
+
+	switch {
+	case isInteger(v):
+	case isFloat(v):
+	case kind == reflect.String:
+
+	default:
+		panic(fmt.Sprintf("LessThan: unexpected kind %v", kind))
+	}
+
+	return &lessThanMatcher{v}
+}
+
+type lessThanMatcher struct {
+	limit reflect.Value
+}
+
+func (m *lessThanMatcher) Description() string {
+	// Special case: make it clear that strings are strings.
+	if m.limit.Kind() == reflect.String {
+		return fmt.Sprintf("less than \"%s\"", m.limit.String())
+	}
+
+	return fmt.Sprintf("less than %v", m.limit.Interface())
+}
+
+func compareIntegers(v1, v2 reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(v1) && isSignedInteger(v2):
+		if v1.Int() < v2.Int() {
+			err = nil
+		}
+		return
+
+	case isSignedInteger(v1) && isUnsignedInteger(v2):
+		if v1.Int() < 0 || uint64(v1.Int()) < v2.Uint() {
+			err = nil
+		}
+		return
+
+	case isUnsignedInteger(v1) && isSignedInteger(v2):
+		if v1.Uint() <= math.MaxInt64 && int64(v1.Uint()) < v2.Int() {
+			err = nil
+		}
+		return
+
+	case isUnsignedInteger(v1) && isUnsignedInteger(v2):
+		if v1.Uint() < v2.Uint() {
+			err = nil
+		}
+		return
+	}
+
+	panic(fmt.Sprintf("compareIntegers: %v %v", v1, v2))
+}
+
+func getFloat(v reflect.Value) float64 {
+	switch {
+	case isSignedInteger(v):
+		return float64(v.Int())
+
+	case isUnsignedInteger(v):
+		return float64(v.Uint())
+
+	case isFloat(v):
+		return v.Float()
+	}
+
+	panic(fmt.Sprintf("getFloat: %v", v))
+}
+
+func (m *lessThanMatcher) Matches(c interface{}) (err error) {
+	v1 := reflect.ValueOf(c)
+	v2 := m.limit
+
+	err = errors.New("")
+
+	// Handle strings as a special case.
+	if v1.Kind() == reflect.String && v2.Kind() == reflect.String {
+		if v1.String() < v2.String() {
+			err = nil
+		}
+		return
+	}
+
+	// If we get here, we require that we are dealing with integers or floats.
+	v1Legal := isInteger(v1) || isFloat(v1)
+	v2Legal := isInteger(v2) || isFloat(v2)
+	if !v1Legal || !v2Legal {
+		err = NewFatalError("which is not comparable")
+		return
+	}
+
+	// Handle the various comparison cases.
+	switch {
+	// Both integers
+	case isInteger(v1) && isInteger(v2):
+		return compareIntegers(v1, v2)
+
+	// At least one float32
+	case v1.Kind() == reflect.Float32 || v2.Kind() == reflect.Float32:
+		if float32(getFloat(v1)) < float32(getFloat(v2)) {
+			err = nil
+		}
+		return
+
+	// At least one float64
+	case v1.Kind() == reflect.Float64 || v2.Kind() == reflect.Float64:
+		if getFloat(v1) < getFloat(v2) {
+			err = nil
+		}
+		return
+	}
+
+	// We shouldn't get here.
+	panic(fmt.Sprintf("lessThanMatcher.Matches: Shouldn't get here: %v %v", v1, v2))
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/matcher.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/matcher.go
@@ -1,0 +1,86 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package oglematchers provides a set of matchers useful in a testing or
+// mocking framework. These matchers are inspired by and mostly compatible with
+// Google Test for C++ and Google JS Test.
+//
+// This package is used by github.com/smartystreets/assertions/internal/ogletest and
+// github.com/smartystreets/assertions/internal/oglemock, which may be more directly useful if you're not
+// writing your own testing package or defining your own matchers.
+package oglematchers
+
+// A Matcher is some predicate implicitly defining a set of values that it
+// matches. For example, GreaterThan(17) matches all numeric values greater
+// than 17, and HasSubstr("taco") matches all strings with the substring
+// "taco".
+//
+// Matchers are typically exposed to tests via constructor functions like
+// HasSubstr. In order to implement such a function you can either define your
+// own matcher type or use NewMatcher.
+type Matcher interface {
+	// Check whether the supplied value belongs to the the set defined by the
+	// matcher. Return a non-nil error if and only if it does not.
+	//
+	// The error describes why the value doesn't match. The error text is a
+	// relative clause that is suitable for being placed after the value. For
+	// example, a predicate that matches strings with a particular substring may,
+	// when presented with a numerical value, return the following error text:
+	//
+	//     "which is not a string"
+	//
+	// Then the failure message may look like:
+	//
+	//     Expected: has substring "taco"
+	//     Actual:   17, which is not a string
+	//
+	// If the error is self-apparent based on the description of the matcher, the
+	// error text may be empty (but the error still non-nil). For example:
+	//
+	//     Expected: 17
+	//     Actual:   19
+	//
+	// If you are implementing a new matcher, see also the documentation on
+	// FatalError.
+	Matches(candidate interface{}) error
+
+	// Description returns a string describing the property that values matching
+	// this matcher have, as a verb phrase where the subject is the value. For
+	// example, "is greather than 17" or "has substring "taco"".
+	Description() string
+}
+
+// FatalError is an implementation of the error interface that may be returned
+// from matchers, indicating the error should be propagated. Returning a
+// *FatalError indicates that the matcher doesn't process values of the
+// supplied type, or otherwise doesn't know how to handle the value.
+//
+// For example, if GreaterThan(17) returned false for the value "taco" without
+// a fatal error, then Not(GreaterThan(17)) would return true. This is
+// technically correct, but is surprising and may mask failures where the wrong
+// sort of matcher is accidentally used. Instead, GreaterThan(17) can return a
+// fatal error, which will be propagated by Not().
+type FatalError struct {
+	errorText string
+}
+
+// NewFatalError creates a FatalError struct with the supplied error text.
+func NewFatalError(s string) *FatalError {
+	return &FatalError{s}
+}
+
+func (e *FatalError) Error() string {
+	return e.errorText
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/matches_regexp.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/matches_regexp.go
@@ -1,0 +1,69 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+)
+
+// MatchesRegexp returns a matcher that matches strings and byte slices whose
+// contents match the supplied regular expression. The semantics are those of
+// regexp.Match. In particular, that means the match is not implicitly anchored
+// to the ends of the string: MatchesRegexp("bar") will match "foo bar baz".
+func MatchesRegexp(pattern string) Matcher {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		panic("MatchesRegexp: " + err.Error())
+	}
+
+	return &matchesRegexpMatcher{re}
+}
+
+type matchesRegexpMatcher struct {
+	re *regexp.Regexp
+}
+
+func (m *matchesRegexpMatcher) Description() string {
+	return fmt.Sprintf("matches regexp \"%s\"", m.re.String())
+}
+
+func (m *matchesRegexpMatcher) Matches(c interface{}) (err error) {
+	v := reflect.ValueOf(c)
+	isString := v.Kind() == reflect.String
+	isByteSlice := v.Kind() == reflect.Slice && v.Elem().Kind() == reflect.Uint8
+
+	err = errors.New("")
+
+	switch {
+	case isString:
+		if m.re.MatchString(v.String()) {
+			err = nil
+		}
+
+	case isByteSlice:
+		if m.re.Match(v.Bytes()) {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not a string or []byte")
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/new_matcher.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/new_matcher.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+// Create a matcher with the given description and predicate function, which
+// will be invoked to handle calls to Matchers.
+//
+// Using this constructor may be a convenience over defining your own type that
+// implements Matcher if you do not need any logic in your Description method.
+func NewMatcher(
+	predicate func(interface{}) error,
+	description string) Matcher {
+	return &predicateMatcher{
+		predicate:   predicate,
+		description: description,
+	}
+}
+
+type predicateMatcher struct {
+	predicate   func(interface{}) error
+	description string
+}
+
+func (pm *predicateMatcher) Matches(c interface{}) error {
+	return pm.predicate(c)
+}
+
+func (pm *predicateMatcher) Description() string {
+	return pm.description
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/not.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/not.go
@@ -1,0 +1,53 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Not returns a matcher that inverts the set of values matched by the wrapped
+// matcher. It does not transform the result for values for which the wrapped
+// matcher returns a fatal error.
+func Not(m Matcher) Matcher {
+	return &notMatcher{m}
+}
+
+type notMatcher struct {
+	wrapped Matcher
+}
+
+func (m *notMatcher) Matches(c interface{}) (err error) {
+	err = m.wrapped.Matches(c)
+
+	// Did the wrapped matcher say yes?
+	if err == nil {
+		return errors.New("")
+	}
+
+	// Did the wrapped matcher return a fatal error?
+	if _, isFatal := err.(*FatalError); isFatal {
+		return err
+	}
+
+	// The wrapped matcher returned a non-fatal error.
+	return nil
+}
+
+func (m *notMatcher) Description() string {
+	return fmt.Sprintf("not(%s)", m.wrapped.Description())
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/panics.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/panics.go
@@ -1,0 +1,74 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Panics matches zero-arg functions which, when invoked, panic with an error
+// that matches the supplied matcher.
+//
+// NOTE(jacobsa): This matcher cannot detect the case where the function panics
+// using panic(nil), by design of the language. See here for more info:
+//
+//     http://goo.gl/9aIQL
+//
+func Panics(m Matcher) Matcher {
+	return &panicsMatcher{m}
+}
+
+type panicsMatcher struct {
+	wrappedMatcher Matcher
+}
+
+func (m *panicsMatcher) Description() string {
+	return "panics with: " + m.wrappedMatcher.Description()
+}
+
+func (m *panicsMatcher) Matches(c interface{}) (err error) {
+	// Make sure c is a zero-arg function.
+	v := reflect.ValueOf(c)
+	if v.Kind() != reflect.Func || v.Type().NumIn() != 0 {
+		err = NewFatalError("which is not a zero-arg function")
+		return
+	}
+
+	// Call the function and check its panic error.
+	defer func() {
+		if e := recover(); e != nil {
+			err = m.wrappedMatcher.Matches(e)
+
+			// Set a clearer error message if the matcher said no.
+			if err != nil {
+				wrappedClause := ""
+				if err.Error() != "" {
+					wrappedClause = ", " + err.Error()
+				}
+
+				err = errors.New(fmt.Sprintf("which panicked with: %v%s", e, wrappedClause))
+			}
+		}
+	}()
+
+	v.Call([]reflect.Value{})
+
+	// If we get here, the function didn't panic.
+	err = errors.New("which didn't panic")
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/pointee.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/pointee.go
@@ -1,0 +1,65 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Return a matcher that matches non-nil pointers whose pointee matches the
+// wrapped matcher.
+func Pointee(m Matcher) Matcher {
+	return &pointeeMatcher{m}
+}
+
+type pointeeMatcher struct {
+	wrapped Matcher
+}
+
+func (m *pointeeMatcher) Matches(c interface{}) (err error) {
+	// Make sure the candidate is of the appropriate type.
+	cv := reflect.ValueOf(c)
+	if !cv.IsValid() || cv.Kind() != reflect.Ptr {
+		return NewFatalError("which is not a pointer")
+	}
+
+	// Make sure the candidate is non-nil.
+	if cv.IsNil() {
+		return NewFatalError("")
+	}
+
+	// Defer to the wrapped matcher. Fix up empty errors so that failure messages
+	// are more helpful than just printing a pointer for "Actual".
+	pointee := cv.Elem().Interface()
+	err = m.wrapped.Matches(pointee)
+	if err != nil && err.Error() == "" {
+		s := fmt.Sprintf("whose pointee is %v", pointee)
+
+		if _, ok := err.(*FatalError); ok {
+			err = NewFatalError(s)
+		} else {
+			err = errors.New(s)
+		}
+	}
+
+	return err
+}
+
+func (m *pointeeMatcher) Description() string {
+	return fmt.Sprintf("pointee(%s)", m.wrapped.Description())
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
@@ -1,0 +1,36 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+// transformDescription returns a matcher that is equivalent to the supplied
+// one, except that it has the supplied description instead of the one attached
+// to the existing matcher.
+func transformDescription(m Matcher, newDesc string) Matcher {
+	return &transformDescriptionMatcher{newDesc, m}
+}
+
+type transformDescriptionMatcher struct {
+	desc string
+	wrappedMatcher Matcher
+}
+
+func (m *transformDescriptionMatcher) Description() string {
+	return m.desc
+}
+
+func (m *transformDescriptionMatcher) Matches(c interface{}) error {
+	return m.wrappedMatcher.Matches(c)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/action.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/action.go
@@ -1,0 +1,36 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+import (
+	"reflect"
+)
+
+// Action represents an action to be taken in response to a call to a mock
+// method.
+type Action interface {
+	// Set the signature of the function with which this action is being used.
+	// This must be called before Invoke is called.
+	SetSignature(signature reflect.Type) error
+
+	// Invoke runs the specified action, given the arguments to the mock method.
+	// It returns zero or more values that may be treated as the return values of
+	// the method. If the action doesn't return any values, it may return the nil
+	// slice.
+	//
+	// You must call SetSignature before calling Invoke.
+	Invoke(methodArgs []interface{}) []interface{}
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/controller.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/controller.go
@@ -1,0 +1,480 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"reflect"
+	"sync"
+)
+
+// PartialExpecation is a function that should be called exactly once with
+// expected arguments or matchers in order to set up an expected method call.
+// See Controller.ExpectMethodCall below. It returns an expectation that can be
+// further modified (e.g. by calling WillOnce).
+//
+// If the arguments are of the wrong type, the function reports a fatal error
+// and returns nil.
+type PartialExpecation func(...interface{}) Expectation
+
+// Controller represents an object that implements the central logic of
+// oglemock: recording and verifying expectations, responding to mock method
+// calls, and so on.
+type Controller interface {
+	// ExpectCall expresses an expectation that the method of the given name
+	// should be called on the supplied mock object. It returns a function that
+	// should be called with the expected arguments, matchers for the arguments,
+	// or a mix of both.
+	//
+	// fileName and lineNumber should indicate the line on which the expectation
+	// was made, if known.
+	//
+	// For example:
+	//
+	//     mockWriter := [...]
+	//     controller.ExpectCall(mockWriter, "Write", "foo.go", 17)(ElementsAre(0x1))
+	//         .WillOnce(Return(1, nil))
+	//
+	// If the mock object doesn't have a method of the supplied name, the
+	// function reports a fatal error and returns nil.
+	ExpectCall(
+		o MockObject,
+		methodName string,
+		fileName string,
+		lineNumber int) PartialExpecation
+
+	// Finish causes the controller to check for any unsatisfied expectations,
+	// and report them as errors if they exist.
+	//
+	// The controller may panic if any of its methods (including this one) are
+	// called after Finish is called.
+	Finish()
+
+	// HandleMethodCall looks for a registered expectation matching the call of
+	// the given method on mock object o, invokes the appropriate action (if
+	// any), and returns the values returned by that action (if any).
+	//
+	// If the action returns nothing, the controller returns zero values. If
+	// there is no matching expectation, the controller reports an error and
+	// returns zero values.
+	//
+	// If the mock object doesn't have a method of the supplied name, the
+	// arguments are of the wrong type, or the action returns the wrong types,
+	// the function reports a fatal error.
+	//
+	// HandleMethodCall is exported for the sake of mock implementations, and
+	// should not be used directly.
+	HandleMethodCall(
+		o MockObject,
+		methodName string,
+		fileName string,
+		lineNumber int,
+		args []interface{}) []interface{}
+}
+
+// methodMap represents a map from method name to set of expectations for that
+// method.
+type methodMap map[string][]*InternalExpectation
+
+// objectMap represents a map from mock object ID to a methodMap for that object.
+type objectMap map[uintptr]methodMap
+
+// NewController sets up a fresh controller, without any expectations set, and
+// configures the controller to use the supplied error reporter.
+func NewController(reporter ErrorReporter) Controller {
+	return &controllerImpl{reporter, sync.RWMutex{}, objectMap{}}
+}
+
+type controllerImpl struct {
+	reporter ErrorReporter
+
+	mutex                sync.RWMutex
+	expectationsByObject objectMap // Protected by mutex
+}
+
+// Return the list of registered expectations for the named method of the
+// supplied object, or an empty slice if none have been registered. When this
+// method returns, it is guaranteed that c.expectationsByObject has an entry
+// for the object.
+//
+// c.mutex must be held for reading.
+func (c *controllerImpl) getExpectationsLocked(
+	o MockObject,
+	methodName string) []*InternalExpectation {
+	id := o.Oglemock_Id()
+
+	// Look up the mock object.
+	expectationsByMethod, ok := c.expectationsByObject[id]
+	if !ok {
+		expectationsByMethod = methodMap{}
+		c.expectationsByObject[id] = expectationsByMethod
+	}
+
+	result, ok := expectationsByMethod[methodName]
+	if !ok {
+		return []*InternalExpectation{}
+	}
+
+	return result
+}
+
+// Add an expectation to the list registered for the named method of the
+// supplied mock object.
+//
+// c.mutex must be held for writing.
+func (c *controllerImpl) addExpectationLocked(
+	o MockObject,
+	methodName string,
+	exp *InternalExpectation) {
+	// Get the existing list.
+	existing := c.getExpectationsLocked(o, methodName)
+
+	// Store a modified list.
+	id := o.Oglemock_Id()
+	c.expectationsByObject[id][methodName] = append(existing, exp)
+}
+
+func (c *controllerImpl) ExpectCall(
+	o MockObject,
+	methodName string,
+	fileName string,
+	lineNumber int) PartialExpecation {
+	// Find the signature for the requested method.
+	ov := reflect.ValueOf(o)
+	method := ov.MethodByName(methodName)
+	if method.Kind() == reflect.Invalid {
+		c.reporter.ReportFatalError(
+			fileName,
+			lineNumber,
+			errors.New("Unknown method: "+methodName))
+		return nil
+	}
+
+	partialAlreadyCalled := false // Protected by c.mutex
+	return func(args ...interface{}) Expectation {
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+
+		// This function should only be called once.
+		if partialAlreadyCalled {
+			c.reporter.ReportFatalError(
+				fileName,
+				lineNumber,
+				errors.New("Partial expectation called more than once."))
+			return nil
+		}
+
+		partialAlreadyCalled = true
+
+		// Make sure that the number of args is legal. Keep in mind that the
+		// method's type has an extra receiver arg.
+		if len(args) != method.Type().NumIn() {
+			c.reporter.ReportFatalError(
+				fileName,
+				lineNumber,
+				errors.New(
+					fmt.Sprintf(
+						"Expectation for %s given wrong number of arguments: "+
+							"expected %d, got %d.",
+						methodName,
+						method.Type().NumIn(),
+						len(args))))
+			return nil
+		}
+
+		// Create an expectation and insert it into the controller's map.
+		exp := InternalNewExpectation(
+			c.reporter,
+			method.Type(),
+			args,
+			fileName,
+			lineNumber)
+
+		c.addExpectationLocked(o, methodName, exp)
+
+		// Return the expectation to the user.
+		return exp
+	}
+}
+
+func (c *controllerImpl) Finish() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// Check whether the minimum cardinality for each registered expectation has
+	// been satisfied.
+	for _, expectationsByMethod := range c.expectationsByObject {
+		for methodName, expectations := range expectationsByMethod {
+			for _, exp := range expectations {
+				exp.mutex.Lock()
+				defer exp.mutex.Unlock()
+
+				minCardinality, _ := computeCardinalityLocked(exp)
+				if exp.NumMatches < minCardinality {
+					c.reporter.ReportError(
+						exp.FileName,
+						exp.LineNumber,
+						errors.New(
+							fmt.Sprintf(
+								"Unsatisfied expectation; expected %s to be called "+
+									"at least %d times; called %d times.",
+								methodName,
+								minCardinality,
+								exp.NumMatches)))
+				}
+			}
+		}
+	}
+}
+
+// expectationMatches checks the matchers for the expectation against the
+// supplied arguments.
+func expectationMatches(exp *InternalExpectation, args []interface{}) bool {
+	matchers := exp.ArgMatchers
+	if len(args) != len(matchers) {
+		panic("expectationMatches: len(args)")
+	}
+
+	// Check each matcher.
+	for i, matcher := range matchers {
+		if err := matcher.Matches(args[i]); err != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Return the expectation that matches the supplied arguments. If there is more
+// than one such expectation, the one furthest along in the list for the method
+// is returned. If there is no such expectation, nil is returned.
+//
+// c.mutex must be held for reading.
+func (c *controllerImpl) chooseExpectationLocked(
+	o MockObject,
+	methodName string,
+	args []interface{}) *InternalExpectation {
+	// Do we have any expectations for this method?
+	expectations := c.getExpectationsLocked(o, methodName)
+	if len(expectations) == 0 {
+		return nil
+	}
+
+	for i := len(expectations) - 1; i >= 0; i-- {
+		if expectationMatches(expectations[i], args) {
+			return expectations[i]
+		}
+	}
+
+	return nil
+}
+
+// makeZeroReturnValues creates a []interface{} containing appropriate zero
+// values for returning from the supplied method type.
+func makeZeroReturnValues(signature reflect.Type) []interface{} {
+	result := make([]interface{}, signature.NumOut())
+
+	for i, _ := range result {
+		outType := signature.Out(i)
+		zeroVal := reflect.Zero(outType)
+		result[i] = zeroVal.Interface()
+	}
+
+	return result
+}
+
+// computeCardinality decides on the [min, max] range of the number of expected
+// matches for the supplied expectations, according to the rules documented in
+// expectation.go.
+//
+// exp.mutex must be held for reading.
+func computeCardinalityLocked(exp *InternalExpectation) (min, max uint) {
+	// Explicit cardinality.
+	if exp.ExpectedNumMatches >= 0 {
+		min = uint(exp.ExpectedNumMatches)
+		max = min
+		return
+	}
+
+	// Implicit count based on one-time actions.
+	if len(exp.OneTimeActions) != 0 {
+		min = uint(len(exp.OneTimeActions))
+		max = min
+
+		// If there is a fallback action, this is only a lower bound.
+		if exp.FallbackAction != nil {
+			max = math.MaxUint32
+		}
+
+		return
+	}
+
+	// Implicit lack of restriction based on a fallback action being configured.
+	if exp.FallbackAction != nil {
+		min = 0
+		max = math.MaxUint32
+		return
+	}
+
+	// Implicit cardinality of one.
+	min = 1
+	max = 1
+	return
+}
+
+// chooseAction returns the action that should be invoked for the i'th match to
+// the supplied expectation (counting from zero). If the implicit "return zero
+// values" action should be used, it returns nil.
+//
+// exp.mutex must be held for reading.
+func chooseActionLocked(i uint, exp *InternalExpectation) Action {
+	// Exhaust one-time actions first.
+	if i < uint(len(exp.OneTimeActions)) {
+		return exp.OneTimeActions[i]
+	}
+
+	// Fallback action (or nil if none is configured).
+	return exp.FallbackAction
+}
+
+// Find an action for the method call, updating expectation match state in the
+// process. Return either an action that should be invoked or a set of zero
+// values to return immediately.
+//
+// This is split out from HandleMethodCall in order to more easily avoid
+// invoking the action with locks held.
+func (c *controllerImpl) chooseActionAndUpdateExpectations(
+	o MockObject,
+	methodName string,
+	fileName string,
+	lineNumber int,
+	args []interface{},
+) (action Action, zeroVals []interface{}) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// Find the signature for the requested method.
+	ov := reflect.ValueOf(o)
+	method := ov.MethodByName(methodName)
+	if method.Kind() == reflect.Invalid {
+		c.reporter.ReportFatalError(
+			fileName,
+			lineNumber,
+			errors.New("Unknown method: "+methodName),
+		)
+
+		// Should never get here in real code.
+		log.Println("ReportFatalError unexpectedly returned.")
+		return
+	}
+
+	// HACK(jacobsa): Make sure we got the correct number of arguments. This will
+	// need to be refined when issue #5 (variadic methods) is handled.
+	if len(args) != method.Type().NumIn() {
+		c.reporter.ReportFatalError(
+			fileName,
+			lineNumber,
+			errors.New(
+				fmt.Sprintf(
+					"Wrong number of arguments: expected %d; got %d",
+					method.Type().NumIn(),
+					len(args),
+				),
+			),
+		)
+
+		// Should never get here in real code.
+		log.Println("ReportFatalError unexpectedly returned.")
+		return
+	}
+
+	// Find an expectation matching this call.
+	expectation := c.chooseExpectationLocked(o, methodName, args)
+	if expectation == nil {
+		c.reporter.ReportError(
+			fileName,
+			lineNumber,
+			errors.New(
+				fmt.Sprintf("Unexpected call to %s with args: %v", methodName, args),
+			),
+		)
+
+		zeroVals = makeZeroReturnValues(method.Type())
+		return
+	}
+
+	expectation.mutex.Lock()
+	defer expectation.mutex.Unlock()
+
+	// Increase the number of matches recorded, and check whether we're over the
+	// number expected.
+	expectation.NumMatches++
+	_, maxCardinality := computeCardinalityLocked(expectation)
+	if expectation.NumMatches > maxCardinality {
+		c.reporter.ReportError(
+			expectation.FileName,
+			expectation.LineNumber,
+			errors.New(
+				fmt.Sprintf(
+					"Unexpected call to %s: "+
+						"expected to be called at most %d times; called %d times.",
+					methodName,
+					maxCardinality,
+					expectation.NumMatches,
+				),
+			),
+		)
+
+		zeroVals = makeZeroReturnValues(method.Type())
+		return
+	}
+
+	// Choose an action to invoke. If there is none, just return zero values.
+	action = chooseActionLocked(expectation.NumMatches-1, expectation)
+	if action == nil {
+		zeroVals = makeZeroReturnValues(method.Type())
+		return
+	}
+
+	// Let the action take over.
+	return
+}
+
+func (c *controllerImpl) HandleMethodCall(
+	o MockObject,
+	methodName string,
+	fileName string,
+	lineNumber int,
+	args []interface{},
+) []interface{} {
+	// Figure out whether to invoke an action or return zero values.
+	action, zeroVals := c.chooseActionAndUpdateExpectations(
+		o,
+		methodName,
+		fileName,
+		lineNumber,
+		args,
+	)
+
+	if action != nil {
+		return action.Invoke(args)
+	}
+
+	return zeroVals
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/createmock/createmock.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/createmock/createmock.go
@@ -1,0 +1,245 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// createmock is used to generate source code for mock versions of interfaces
+// from installed packages.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"text/template"
+
+	// Ensure that the generate package, which is used by the generated code, is
+	// installed by goinstall.
+	_ "github.com/smartystreets/assertions/internal/oglemock/generate"
+)
+
+var fSamePackage = flag.Bool(
+	"same_package",
+	false,
+	"Generate output appropriate for including in the same package as the "+
+		"mocked interfaces.")
+
+// A template for generated code that is used to print the result.
+const tmplStr = `
+{{$interfacePkgPath := .InterfacePkgPath}}
+
+package main
+
+import (
+	{{range $identifier, $import := .Imports}}
+		{{$identifier}} "{{$import}}"
+	{{end}}
+)
+
+func getTypeForPtr(ptr interface{}) reflect.Type {
+	return reflect.TypeOf(ptr).Elem()
+}
+
+func main() {
+	// Reduce noise in logging output.
+	log.SetFlags(0)
+
+	interfaces := []reflect.Type{
+		{{range $typeName := .TypeNames}}
+			getTypeForPtr((*{{pathBase $interfacePkgPath}}.{{$typeName}})(nil)),
+		{{end}}
+	}
+
+	err := generate.GenerateMockSource(
+		os.Stdout,
+		"{{.OutputPkgPath}}",
+		interfaces)
+
+	if err != nil {
+		log.Fatalf("Error generating mock source: %v", err)
+	}
+}
+`
+
+// A map from import identifier to package to use that identifier for,
+// containing elements for each import needed by the generated code.
+type importMap map[string]string
+
+type tmplArg struct {
+	// The full path of the package from which the interfaces come.
+	InterfacePkgPath string
+
+	// The package path to assume for the generated code.
+	OutputPkgPath string
+
+	// Imports needed by the generated code.
+	Imports importMap
+
+	// Types to be mocked, relative to their package's name.
+	TypeNames []string
+}
+
+var unknownPackageRegexp = regexp.MustCompile(
+	`tool\.go:\d+:\d+: cannot find package "([^"]+)"`)
+
+var undefinedInterfaceRegexp = regexp.MustCompile(`tool\.go:\d+: undefined: [\pL_0-9]+\.([\pL_0-9]+)`)
+
+// Does the 'go build' output indicate that a package wasn't found? If so,
+// return the name of the package.
+func findUnknownPackage(output []byte) *string {
+	if match := unknownPackageRegexp.FindSubmatch(output); match != nil {
+		res := string(match[1])
+		return &res
+	}
+
+	return nil
+}
+
+// Does the 'go build' output indicate that an interface wasn't found? If so,
+// return the name of the interface.
+func findUndefinedInterface(output []byte) *string {
+	if match := undefinedInterfaceRegexp.FindSubmatch(output); match != nil {
+		res := string(match[1])
+		return &res
+	}
+
+	return nil
+}
+
+// Split out from main so that deferred calls are executed even in the event of
+// an error.
+func run() error {
+	// Reduce noise in logging output.
+	log.SetFlags(0)
+
+	// Check the command-line arguments.
+	flag.Parse()
+
+	cmdLineArgs := flag.Args()
+	if len(cmdLineArgs) < 2 {
+		return errors.New("Usage: createmock [package] [interface ...]")
+	}
+
+	// Create a temporary directory inside of $GOPATH to hold generated code.
+	buildPkg, err := build.Import("github.com/smartystreets/assertions/internal/oglemock", "", build.FindOnly)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Couldn't find oglemock in $GOPATH: %v", err))
+	}
+
+	tmpDir, err := ioutil.TempDir(buildPkg.SrcRoot, "tmp-createmock-")
+	if err != nil {
+		return errors.New(fmt.Sprintf("Creating temp dir: %v", err))
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	// Create a file to hold generated code.
+	codeFile, err := os.Create(path.Join(tmpDir, "tool.go"))
+	if err != nil {
+		return errors.New(fmt.Sprintf("Couldn't create a file to hold code: %v", err))
+	}
+
+	// Create an appropriate path for the built binary.
+	binaryPath := path.Join(tmpDir, "tool")
+
+	// Create an appropriate template argument.
+	arg := tmplArg{
+		InterfacePkgPath: cmdLineArgs[0],
+		TypeNames:        cmdLineArgs[1:],
+	}
+
+	if *fSamePackage {
+		arg.OutputPkgPath = arg.InterfacePkgPath
+	} else {
+		arg.OutputPkgPath = "mock_" + path.Base(arg.InterfacePkgPath)
+	}
+
+	arg.Imports = make(importMap)
+	arg.Imports[path.Base(arg.InterfacePkgPath)] = arg.InterfacePkgPath
+	arg.Imports["generate"] = "github.com/smartystreets/assertions/internal/oglemock/generate"
+	arg.Imports["log"] = "log"
+	arg.Imports["os"] = "os"
+	arg.Imports["reflect"] = "reflect"
+
+	// Execute the template to generate code that will itself generate the mock
+	// code. Write the code to the temp file.
+	tmpl := template.Must(
+		template.New("code").Funcs(
+			template.FuncMap{
+				"pathBase": path.Base,
+			}).Parse(tmplStr))
+	if err := tmpl.Execute(codeFile, arg); err != nil {
+		return errors.New(fmt.Sprintf("Error executing template: %v", err))
+	}
+
+	codeFile.Close()
+
+	// Attempt to build the code.
+	cmd := exec.Command("go", "build", "-o", binaryPath)
+	cmd.Dir = tmpDir
+	buildOutput, err := cmd.CombinedOutput()
+
+	if err != nil {
+		// Did the compilation fail due to the user-specified package not being found?
+		pkg := findUnknownPackage(buildOutput)
+		if pkg != nil && *pkg == arg.InterfacePkgPath {
+			return errors.New(fmt.Sprintf("Unknown package: %s", *pkg))
+		}
+
+		// Did the compilation fail due to an unknown interface?
+		if in := findUndefinedInterface(buildOutput); in != nil {
+			return errors.New(fmt.Sprintf("Unknown interface: %s", *in))
+		}
+
+		// Otherwise return a generic error.
+		return errors.New(fmt.Sprintf(
+			"%s\n\nError building generated code:\n\n"+
+				"    %v\n\nPlease report this oglemock bug.",
+			buildOutput,
+			err))
+	}
+
+	// Run the binary.
+	cmd = exec.Command(binaryPath)
+	binaryOutput, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return errors.New(fmt.Sprintf(
+			"%s\n\nError running generated code:\n\n"+
+				"    %v\n\n Please report this oglemock bug.",
+			binaryOutput,
+			err))
+	}
+
+	// Copy its output.
+	_, err = os.Stdout.Write(binaryOutput)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error copying binary output: %v", err))
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		os.Exit(1)
+	}
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/do_all.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/do_all.go
@@ -1,0 +1,53 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Create an Action that invokes the supplied actions one after another. The
+// return values from the final action are used; others are ignored.
+func DoAll(first Action, others ...Action) Action {
+	return &doAll{
+		wrapped: append([]Action{first}, others...),
+	}
+}
+
+type doAll struct {
+	wrapped []Action
+}
+
+func (a *doAll) SetSignature(signature reflect.Type) (err error) {
+	for i, w := range a.wrapped {
+		err = w.SetSignature(signature)
+		if err != nil {
+			err = fmt.Errorf("Action %v: %v", i, err)
+			return
+		}
+	}
+
+	return
+}
+
+func (a *doAll) Invoke(methodArgs []interface{}) (rets []interface{}) {
+	for _, w := range a.wrapped {
+		rets = w.Invoke(methodArgs)
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/doc.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package oglemock provides a mocking framework for unit tests.
+//
+// Among its features are the following:
+//
+//  *  An extensive and extensible set of matchers for expressing call
+//     expectations (provided by the oglematchers package).
+//
+//  *  Style and semantics similar to Google Mock and Google JS Test.
+//
+//  *  Easy integration with the ogletest unit testing framework.
+//
+// See https://github.com/smartystreets/assertions/internal/oglemock for more information.
+package oglemock

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/error_reporter.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/error_reporter.go
@@ -1,0 +1,29 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+// ErrorReporter is an interface that wraps methods for reporting errors that
+// should cause test failures.
+type ErrorReporter interface {
+	// Report that some failure (e.g. an unsatisfied expectation) occurred. If
+	// known, fileName and lineNumber should contain information about where it
+	// occurred. The test may continue if the test framework supports it.
+	ReportError(fileName string, lineNumber int, err error)
+
+	// Like ReportError, but the test should be halted immediately. It is assumed
+	// that this method does not return.
+	ReportFatalError(fileName string, lineNumber int, err error)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/expectation.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/expectation.go
@@ -1,0 +1,59 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+// Expectation is an expectation for zero or more calls to a mock method with
+// particular arguments or sets of arguments.
+type Expectation interface {
+	// Times expresses that a matching method call should happen exactly N times.
+	// Times must not be called more than once, and must not be called after
+	// WillOnce or WillRepeatedly.
+	//
+	// The full rules for the cardinality of an expectation are as follows:
+	//
+	//  1. If an explicit cardinality is set with Times(N), then anything other
+	//     than exactly N matching calls will cause a test failure.
+	//
+	//  2. Otherwise, if there are any one-time actions set up, then it is
+	//     expected there will be at least that many matching calls. If there is
+	//     not also a fallback action, then it is expected that there will be
+	//     exactly that many.
+	//
+	//  3. Otherwise, if there is a fallback action configured, any number of
+	//     matching calls (including zero) is allowed.
+	//
+	//  4. Otherwise, the implicit cardinality is one.
+	//
+	Times(n uint) Expectation
+
+	// WillOnce configures a "one-time action". WillOnce can be called zero or
+	// more times, but must be called after any call to Times and before any call
+	// to WillRepeatedly.
+	//
+	// When matching method calls are made on the mock object, one-time actions
+	// are invoked one per matching call in the order that they were set up until
+	// they are exhausted. Afterward the fallback action, if any, will be used.
+	WillOnce(a Action) Expectation
+
+	// WillRepeatedly configures a "fallback action". WillRepeatedly can be
+	// called zero or one times, and must not be called before Times or WillOnce.
+	//
+	// Once all one-time actions are exhausted (see above), the fallback action
+	// will be invoked for any further method calls. If WillRepeatedly is not
+	// called, the fallback action is implicitly an action that returns zero
+	// values for the method's return values.
+	WillRepeatedly(a Action) Expectation
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/generate/generate.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/generate/generate.go
@@ -1,0 +1,369 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package generate implements code generation for mock classes. This is an
+// implementation detail of the createmock command, which you probably want to
+// use directly instead.
+package generate
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io"
+	"path"
+	"reflect"
+	"regexp"
+	"text/template"
+)
+
+const gTmplStr = `
+// This file was auto-generated using createmock. See the following page for
+// more information:
+//
+//     https://github.com/smartystreets/assertions/internal/oglemock
+//
+
+package {{pathBase .OutputPkgPath}}
+
+import (
+	{{range $identifier, $import := .Imports}}{{$identifier}} "{{$import}}"
+	{{end}}
+)
+
+{{range .Interfaces}}
+	{{$interfaceName := printf "Mock%s" .Name}}
+	{{$structName := printf "mock%s" .Name}}
+
+	type {{$interfaceName}} interface {
+		{{getTypeString .}}
+		oglemock.MockObject
+	}
+
+	type {{$structName}} struct {
+		controller oglemock.Controller
+		description string
+	}
+	
+	func New{{printf "Mock%s" .Name}}(
+		c oglemock.Controller,
+		desc string) {{$interfaceName}} {
+	  return &{{$structName}}{
+			controller: c,
+			description: desc,
+		}
+	}
+	
+	func (m *{{$structName}}) Oglemock_Id() uintptr {
+		return uintptr(unsafe.Pointer(m))
+	}
+	
+	func (m *{{$structName}}) Oglemock_Description() string {
+		return m.description
+	}
+
+	{{range getMethods .}}
+	  {{$funcType := .Type}}
+	  {{$inputTypes := getInputs $funcType}}
+	  {{$outputTypes := getOutputs $funcType}}
+
+		func (m *{{$structName}}) {{.Name}}({{range $i, $type := $inputTypes}}p{{$i}} {{getInputTypeString $i $funcType}}, {{end}}) ({{range $i, $type := $outputTypes}}o{{$i}} {{getTypeString $type}}, {{end}}) {
+			// Get a file name and line number for the caller.
+			_, file, line, _ := runtime.Caller(1)
+
+			// Hand the call off to the controller, which does most of the work.
+			retVals := m.controller.HandleMethodCall(
+				m,
+				"{{.Name}}",
+				file,
+				line,
+				[]interface{}{ {{range $i, $type := $inputTypes}}p{{$i}}, {{end}} })
+
+			if len(retVals) != {{len $outputTypes}} {
+				panic(fmt.Sprintf("{{$structName}}.{{.Name}}: invalid return values: %v", retVals))
+			}
+
+			{{range $i, $type := $outputTypes}}
+				// o{{$i}} {{getTypeString $type}}
+				if retVals[{{$i}}] != nil {
+					o{{$i}} = retVals[{{$i}}].({{getTypeString $type}})
+				}
+			{{end}}
+
+			return
+		}
+	{{end}}
+{{end}}
+`
+
+type tmplArg struct {
+	// The set of interfaces to mock, and the full name of the package from which
+	// they all come.
+	Interfaces       []reflect.Type
+	InterfacePkgPath string
+
+	// The package path for the generate code.
+	OutputPkgPath string
+
+	// Imports needed by the interfaces.
+	Imports importMap
+}
+
+func (a *tmplArg) getInputTypeString(i int, ft reflect.Type) string {
+	numInputs := ft.NumIn()
+	if i == numInputs-1 && ft.IsVariadic() {
+		return "..." + a.getTypeString(ft.In(i).Elem())
+	}
+
+	return a.getTypeString(ft.In(i))
+}
+
+func (a *tmplArg) getTypeString(t reflect.Type) string {
+	return typeString(t, a.OutputPkgPath)
+}
+
+func getMethods(it reflect.Type) []reflect.Method {
+	numMethods := it.NumMethod()
+	methods := make([]reflect.Method, numMethods)
+
+	for i := 0; i < numMethods; i++ {
+		methods[i] = it.Method(i)
+	}
+
+	return methods
+}
+
+func getInputs(ft reflect.Type) []reflect.Type {
+	numIn := ft.NumIn()
+	inputs := make([]reflect.Type, numIn)
+
+	for i := 0; i < numIn; i++ {
+		inputs[i] = ft.In(i)
+	}
+
+	return inputs
+}
+
+func getOutputs(ft reflect.Type) []reflect.Type {
+	numOut := ft.NumOut()
+	outputs := make([]reflect.Type, numOut)
+
+	for i := 0; i < numOut; i++ {
+		outputs[i] = ft.Out(i)
+	}
+
+	return outputs
+}
+
+// A map from import identifier to package to use that identifier for,
+// containing elements for each import needed by a set of mocked interfaces.
+type importMap map[string]string
+
+var typePackageIdentifierRegexp = regexp.MustCompile(`^([\pL_0-9]+)\.[\pL_0-9]+$`)
+
+// Add an import for the supplied type, without recursing.
+func addImportForType(imports importMap, t reflect.Type) {
+	// If there is no package path, this is a built-in type and we don't need an
+	// import.
+	pkgPath := t.PkgPath()
+	if pkgPath == "" {
+		return
+	}
+
+	// Work around a bug in Go:
+	//
+	//     http://code.google.com/p/go/issues/detail?id=2660
+	//
+	var errorPtr *error
+	if t == reflect.TypeOf(errorPtr).Elem() {
+		return
+	}
+
+	// Use the identifier that's part of the type's string representation as the
+	// import identifier. This means that we'll do the right thing for package
+	// "foo/bar" with declaration "package baz".
+	match := typePackageIdentifierRegexp.FindStringSubmatch(t.String())
+	if match == nil {
+		return
+	}
+
+	imports[match[1]] = pkgPath
+}
+
+// Add all necessary imports for the type, recursing as appropriate.
+func addImportsForType(imports importMap, t reflect.Type) {
+	// Add any import needed for the type itself.
+	addImportForType(imports, t)
+
+	// Handle special cases where recursion is needed.
+	switch t.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Ptr, reflect.Slice:
+		addImportsForType(imports, t.Elem())
+
+	case reflect.Func:
+		// Input parameters.
+		for i := 0; i < t.NumIn(); i++ {
+			addImportsForType(imports, t.In(i))
+		}
+
+		// Return values.
+		for i := 0; i < t.NumOut(); i++ {
+			addImportsForType(imports, t.Out(i))
+		}
+
+	case reflect.Map:
+		addImportsForType(imports, t.Key())
+		addImportsForType(imports, t.Elem())
+	}
+}
+
+// Add imports for each of the methods of the interface, but not the interface
+// itself.
+func addImportsForInterfaceMethods(imports importMap, it reflect.Type) {
+	// Handle each method.
+	for i := 0; i < it.NumMethod(); i++ {
+		m := it.Method(i)
+		addImportsForType(imports, m.Type)
+	}
+}
+
+// Given a set of interfaces, return a map from import identifier to package to
+// use that identifier for, containing elements for each import needed by the
+// mock versions of those interfaces in a package with the given path.
+func getImports(
+	interfaces []reflect.Type,
+	pkgPath string) importMap {
+	imports := make(importMap)
+	for _, it := range interfaces {
+		addImportForType(imports, it)
+		addImportsForInterfaceMethods(imports, it)
+	}
+
+	// Make sure there are imports for other types used by the generated code
+	// itself.
+	imports["fmt"] = "fmt"
+	imports["oglemock"] = "github.com/smartystreets/assertions/internal/oglemock"
+	imports["runtime"] = "runtime"
+	imports["unsafe"] = "unsafe"
+
+	// Remove any self-imports generated above.
+	for k, v := range imports {
+		if v == pkgPath {
+			delete(imports, k)
+		}
+	}
+
+	return imports
+}
+
+// Given a set of interfaces to mock, write out source code suitable for
+// inclusion in a package with the supplied full package path containing mock
+// implementations of those interfaces.
+func GenerateMockSource(
+	w io.Writer,
+	outputPkgPath string,
+	interfaces []reflect.Type) (err error) {
+	// Sanity-check arguments.
+	if outputPkgPath == "" {
+		return errors.New("Package path must be non-empty.")
+	}
+
+	if len(interfaces) == 0 {
+		return errors.New("List of interfaces must be non-empty.")
+	}
+
+	// Make sure each type is indeed an interface.
+	for _, it := range interfaces {
+		if it.Kind() != reflect.Interface {
+			return errors.New("Invalid type: " + it.String())
+		}
+	}
+
+	// Make sure each interface is from the same package.
+	interfacePkgPath := interfaces[0].PkgPath()
+	for _, t := range interfaces {
+		if t.PkgPath() != interfacePkgPath {
+			err = fmt.Errorf(
+				"Package path mismatch: %q vs. %q",
+				interfacePkgPath,
+				t.PkgPath())
+
+			return
+		}
+	}
+
+	// Set up an appropriate template arg.
+	arg := tmplArg{
+		Interfaces:       interfaces,
+		InterfacePkgPath: interfacePkgPath,
+		OutputPkgPath:    outputPkgPath,
+		Imports:          getImports(interfaces, outputPkgPath),
+	}
+
+	// Configure and parse the template.
+	tmpl := template.New("code")
+	tmpl.Funcs(template.FuncMap{
+		"pathBase":           path.Base,
+		"getMethods":         getMethods,
+		"getInputs":          getInputs,
+		"getOutputs":         getOutputs,
+		"getInputTypeString": arg.getInputTypeString,
+		"getTypeString":      arg.getTypeString,
+	})
+
+	_, err = tmpl.Parse(gTmplStr)
+	if err != nil {
+		err = fmt.Errorf("Parse: %v", err)
+		return
+	}
+
+	// Execute the template, collecting the raw output into a buffer.
+	buf := new(bytes.Buffer)
+	if err := tmpl.Execute(buf, arg); err != nil {
+		return err
+	}
+
+	// Parse the output.
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(
+		fset,
+		path.Base(outputPkgPath+".go"),
+		buf,
+		parser.ParseComments)
+
+	if err != nil {
+		err = fmt.Errorf("parser.ParseFile: %v", err)
+		return
+	}
+
+	// Sort the import lines in the AST in the same way that gofmt does.
+	ast.SortImports(fset, astFile)
+
+	// Pretty-print the AST, using the same options that gofmt does by default.
+	cfg := &printer.Config{
+		Mode:     printer.UseSpaces | printer.TabIndent,
+		Tabwidth: 8,
+	}
+
+	if err = cfg.Fprint(w, fset, astFile); err != nil {
+		return errors.New("Error pretty printing: " + err.Error())
+	}
+
+	return nil
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/generate/type_string.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/generate/type_string.go
@@ -1,0 +1,147 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+)
+
+// Return the string that should be used to refer to the supplied type within
+// the given package. The output is not guaranteed to be pretty, and should be
+// run through a tool like gofmt afterward.
+//
+// For example, a pointer to an io.Reader may be rendered as "*Reader" or
+// "*io.Reader" depending on whether the package path is "io" or not.
+func typeString(
+	t reflect.Type,
+	pkgPath string) (s string) {
+	// Is this type named? If so we use its name, possibly with a package prefix.
+	//
+	// Examples:
+	//
+	//     int
+	//     string
+	//     error
+	//     gcs.Bucket
+	//
+	if t.Name() != "" {
+		if t.PkgPath() == pkgPath {
+			s = t.Name()
+		} else {
+			s = t.String()
+		}
+
+		return
+	}
+
+	// This type is unnamed. Recurse.
+	switch t.Kind() {
+	case reflect.Array:
+		s = fmt.Sprintf("[%d]%s", t.Len(), typeString(t.Elem(), pkgPath))
+
+	case reflect.Chan:
+		s = fmt.Sprintf("%s %s", t.ChanDir(), typeString(t.Elem(), pkgPath))
+
+	case reflect.Func:
+		s = typeString_Func(t, pkgPath)
+
+	case reflect.Interface:
+		s = typeString_Interface(t, pkgPath)
+
+	case reflect.Map:
+		s = fmt.Sprintf(
+			"map[%s]%s",
+			typeString(t.Key(), pkgPath),
+			typeString(t.Elem(), pkgPath))
+
+	case reflect.Ptr:
+		s = fmt.Sprintf("*%s", typeString(t.Elem(), pkgPath))
+
+	case reflect.Slice:
+		s = fmt.Sprintf("[]%s", typeString(t.Elem(), pkgPath))
+
+	case reflect.Struct:
+		s = typeString_Struct(t, pkgPath)
+
+	default:
+		log.Panicf("Unhandled kind %v for type: %v", t.Kind(), t)
+	}
+
+	return
+}
+
+func typeString_FuncOrMethod(
+	name string,
+	t reflect.Type,
+	pkgPath string) (s string) {
+	// Deal with input types.
+	var in []string
+	for i := 0; i < t.NumIn(); i++ {
+		in = append(in, typeString(t.In(i), pkgPath))
+	}
+
+	// And output types.
+	var out []string
+	for i := 0; i < t.NumOut(); i++ {
+		out = append(out, typeString(t.Out(i), pkgPath))
+	}
+
+	// Put it all together.
+	s = fmt.Sprintf(
+		"%s(%s) (%s)",
+		name,
+		strings.Join(in, ", "),
+		strings.Join(out, ", "))
+
+	return
+}
+
+func typeString_Func(
+	t reflect.Type,
+	pkgPath string) (s string) {
+	return typeString_FuncOrMethod("func", t, pkgPath)
+}
+
+func typeString_Struct(
+	t reflect.Type,
+	pkgPath string) (s string) {
+	var fields []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		fString := fmt.Sprintf("%s %s", f.Name, typeString(f.Type, pkgPath))
+		fields = append(fields, fString)
+	}
+
+	s = fmt.Sprintf("struct { %s }", strings.Join(fields, "; "))
+	return
+}
+
+func typeString_Interface(
+	t reflect.Type,
+	pkgPath string) (s string) {
+	var methods []string
+	for i := 0; i < t.NumMethod(); i++ {
+		m := t.Method(i)
+		mString := typeString_FuncOrMethod(m.Name, m.Type, pkgPath)
+		methods = append(methods, mString)
+	}
+
+	s = fmt.Sprintf("interface { %s }", strings.Join(methods, "; "))
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/internal_expectation.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/internal_expectation.go
@@ -1,0 +1,180 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+import (
+	"errors"
+	"fmt"
+	"github.com/smartystreets/assertions/internal/oglematchers"
+	"reflect"
+	"sync"
+)
+
+// InternalExpectation is exported for purposes of testing only. You should not
+// touch it.
+//
+// InternalExpectation represents an expectation for zero or more calls to a
+// mock method, and a set of actions to be taken when those calls are received.
+type InternalExpectation struct {
+	// The signature of the method to which this expectation is bound, for
+	// checking action types.
+	methodSignature reflect.Type
+
+	// An error reporter to use for reporting errors in the way that expectations
+	// are set.
+	errorReporter ErrorReporter
+
+	// A mutex protecting mutable fields of the struct.
+	mutex sync.Mutex
+
+	// Matchers that the arguments to the mock method must satisfy in order to
+	// match this expectation.
+	ArgMatchers []oglematchers.Matcher
+
+	// The name of the file in which this expectation was expressed.
+	FileName string
+
+	// The line number at which this expectation was expressed.
+	LineNumber int
+
+	// The number of times this expectation should be matched, as explicitly
+	// listed by the user. If there was no explicit number expressed, this is -1.
+	ExpectedNumMatches int
+
+	// Actions to be taken for the first N calls, one per call in order, where N
+	// is the length of this slice.
+	OneTimeActions []Action
+
+	// An action to be taken when the one-time actions have expired, or nil if
+	// there is no such action.
+	FallbackAction Action
+
+	// The number of times this expectation has been matched so far.
+	NumMatches uint
+}
+
+// InternalNewExpectation is exported for purposes of testing only. You should
+// not touch it.
+func InternalNewExpectation(
+	reporter ErrorReporter,
+	methodSignature reflect.Type,
+	args []interface{},
+	fileName string,
+	lineNumber int) *InternalExpectation {
+	result := &InternalExpectation{}
+
+	// Store fields that can be stored directly.
+	result.methodSignature = methodSignature
+	result.errorReporter = reporter
+	result.FileName = fileName
+	result.LineNumber = lineNumber
+
+	// Set up defaults.
+	result.ExpectedNumMatches = -1
+	result.OneTimeActions = make([]Action, 0)
+
+	// Set up the ArgMatchers slice, using Equals(x) for each x that is not a
+	// matcher itself.
+	result.ArgMatchers = make([]oglematchers.Matcher, len(args))
+	for i, x := range args {
+		if matcher, ok := x.(oglematchers.Matcher); ok {
+			result.ArgMatchers[i] = matcher
+		} else {
+			result.ArgMatchers[i] = oglematchers.Equals(x)
+		}
+	}
+
+	return result
+}
+
+func (e *InternalExpectation) Times(n uint) Expectation {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	// It is illegal to call this more than once.
+	if e.ExpectedNumMatches != -1 {
+		e.reportFatalError("Times called more than once.")
+		return nil
+	}
+
+	// It is illegal to call this after any actions are configured.
+	if len(e.OneTimeActions) != 0 {
+		e.reportFatalError("Times called after WillOnce.")
+		return nil
+	}
+
+	if e.FallbackAction != nil {
+		e.reportFatalError("Times called after WillRepeatedly.")
+		return nil
+	}
+
+	// Make sure the number is reasonable (and will fit in an int).
+	if n > 1000 {
+		e.reportFatalError("Expectation.Times: N must be at most 1000")
+		return nil
+	}
+
+	e.ExpectedNumMatches = int(n)
+	return e
+}
+
+func (e *InternalExpectation) WillOnce(a Action) Expectation {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	// It is illegal to call this after WillRepeatedly.
+	if e.FallbackAction != nil {
+		e.reportFatalError("WillOnce called after WillRepeatedly.")
+		return nil
+	}
+
+	// Tell the action about the method's signature.
+	if err := a.SetSignature(e.methodSignature); err != nil {
+		e.reportFatalError(fmt.Sprintf("WillOnce given invalid action: %v", err))
+		return nil
+	}
+
+	// Store the action.
+	e.OneTimeActions = append(e.OneTimeActions, a)
+
+	return e
+}
+
+func (e *InternalExpectation) WillRepeatedly(a Action) Expectation {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	// It is illegal to call this twice.
+	if e.FallbackAction != nil {
+		e.reportFatalError("WillRepeatedly called more than once.")
+		return nil
+	}
+
+	// Tell the action about the method's signature.
+	if err := a.SetSignature(e.methodSignature); err != nil {
+		e.reportFatalError(fmt.Sprintf("WillRepeatedly given invalid action: %v", err))
+		return nil
+	}
+
+	// Store the action.
+	e.FallbackAction = a
+
+	return e
+}
+
+func (e *InternalExpectation) reportFatalError(errorText string) {
+	e.errorReporter.ReportFatalError(e.FileName, e.LineNumber, errors.New(errorText))
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/invoke.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/invoke.go
@@ -1,0 +1,73 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Create an Action that invokes the supplied function, returning whatever it
+// returns. The signature of the function must match that of the mocked method
+// exactly.
+func Invoke(f interface{}) Action {
+	// Make sure f is a function.
+	fv := reflect.ValueOf(f)
+	fk := fv.Kind()
+
+	if fk != reflect.Func {
+		desc := "<nil>"
+		if fk != reflect.Invalid {
+			desc = fv.Type().String()
+		}
+
+		panic(fmt.Sprintf("Invoke: expected function, got %s", desc))
+	}
+
+	return &invokeAction{fv}
+}
+
+type invokeAction struct {
+	f reflect.Value
+}
+
+func (a *invokeAction) SetSignature(signature reflect.Type) error {
+	// The signature must match exactly.
+	ft := a.f.Type()
+	if ft != signature {
+		return errors.New(fmt.Sprintf("Invoke: expected %v, got %v", signature, ft))
+	}
+
+	return nil
+}
+
+func (a *invokeAction) Invoke(vals []interface{}) []interface{} {
+	// Create a slice of args for the function.
+	in := make([]reflect.Value, len(vals))
+	for i, x := range vals {
+		in[i] = reflect.ValueOf(x)
+	}
+
+	// Call the function and return its return values.
+	out := a.f.Call(in)
+	result := make([]interface{}, len(out))
+	for i, v := range out {
+		result[i] = v.Interface()
+	}
+
+	return result
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/mock_object.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/mock_object.go
@@ -1,0 +1,30 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+// MockObject is an interface that mock object implementations must conform to
+// in order to register expectations with and hand off calls to a
+// MockController. Users should not interact with this interface directly.
+type MockObject interface {
+	// Oglemock_Id returns an identifier for the mock object that is guaranteed
+	// to be unique within the process at least until the mock object is garbage
+	// collected.
+	Oglemock_Id() uintptr
+
+	// Oglemock_Description returns a description of the mock object that may be
+	// helpful in test failure messages.
+	Oglemock_Description() string
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/return.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/return.go
@@ -1,0 +1,251 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+var intType = reflect.TypeOf(int(0))
+var float64Type = reflect.TypeOf(float64(0))
+var complex128Type = reflect.TypeOf(complex128(0))
+
+// Return creates an Action that returns the values passed to Return as
+// arguments, after suitable legal type conversions. The following rules apply.
+// Given an argument x to Return and a corresponding type T in the method's
+// signature, at least one of the following must hold:
+//
+//  *  x is assignable to T. (See "Assignability" in the language spec.) Note
+//     that this in particular applies that x may be a type that implements an
+//     interface T. It also implies that the nil literal can be used if T is a
+//     pointer, function, interface, slice, channel, or map type.
+//
+//  *  T is any numeric type, and x is an int that is in-range for that type.
+//     This facilities using raw integer constants: Return(17).
+//
+//  *  T is a floating-point or complex number type, and x is a float64.  This
+//     facilities using raw floating-point constants: Return(17.5).
+//
+//  *  T is a complex number type, and x is a complex128. This facilities using
+//     raw complex constants: Return(17+2i).
+//
+func Return(vals ...interface{}) Action {
+	return &returnAction{vals, nil}
+}
+
+type returnAction struct {
+	returnVals []interface{}
+	signature  reflect.Type
+}
+
+func (a *returnAction) Invoke(vals []interface{}) []interface{} {
+	if a.signature == nil {
+		panic("You must first call SetSignature with a valid signature.")
+	}
+
+	res, err := a.buildInvokeResult(a.signature)
+	if err != nil {
+		panic(err)
+	}
+
+	return res
+}
+
+func (a *returnAction) SetSignature(signature reflect.Type) error {
+	if _, err := a.buildInvokeResult(signature); err != nil {
+		return err
+	}
+
+	a.signature = signature
+	return nil
+}
+
+// A version of Invoke that does error checking, used by both public methods.
+func (a *returnAction) buildInvokeResult(
+	sig reflect.Type) (res []interface{}, err error) {
+	// Check the length of the return value.
+	numOut := sig.NumOut()
+	numVals := len(a.returnVals)
+
+	if numOut != numVals {
+		err = errors.New(
+			fmt.Sprintf("Return given %d vals; expected %d.", numVals, numOut))
+		return
+	}
+
+	// Attempt to coerce each return value.
+	res = make([]interface{}, numOut)
+
+	for i, val := range a.returnVals {
+		resType := sig.Out(i)
+		res[i], err = a.coerce(val, resType)
+
+		if err != nil {
+			res = nil
+			err = errors.New(fmt.Sprintf("Return: arg %d: %v", i, err))
+			return
+		}
+	}
+
+	return
+}
+
+func (a *returnAction) coerce(x interface{}, t reflect.Type) (interface{}, error) {
+	xv := reflect.ValueOf(x)
+	rv := reflect.New(t).Elem()
+
+	// Special case: the language spec says that the predeclared identifier nil
+	// is assignable to pointers, functions, interface, slices, channels, and map
+	// types. However, reflect.ValueOf(nil) returns an invalid value that will
+	// not cooperate below. So handle invalid values here, assuming that they
+	// resulted from Return(nil).
+	if !xv.IsValid() {
+		switch t.Kind() {
+		case reflect.Ptr, reflect.Func, reflect.Interface, reflect.Chan, reflect.Slice, reflect.Map, reflect.UnsafePointer:
+			return rv.Interface(), nil
+		}
+
+		return nil, errors.New(fmt.Sprintf("expected %v, given <nil>", t))
+	}
+
+	// If x is assignable to type t, let the reflect package do the heavy
+	// lifting.
+	if reflect.TypeOf(x).AssignableTo(t) {
+		rv.Set(xv)
+		return rv.Interface(), nil
+	}
+
+	// Handle numeric types as described in the documentation on Return.
+	switch {
+	case xv.Type() == intType && a.isNumeric(t):
+		return a.coerceInt(xv.Int(), t)
+
+	case xv.Type() == float64Type && (a.isFloatingPoint(t) || a.isComplex(t)):
+		return a.coerceFloat(xv.Float(), t)
+
+	case xv.Type() == complex128Type && a.isComplex(t):
+		return a.coerceComplex(xv.Complex(), t)
+	}
+
+	// The value wasn't of a legal type.
+	return nil, errors.New(fmt.Sprintf("expected %v, given %v", t, xv.Type()))
+}
+
+func (a *returnAction) isNumeric(t reflect.Type) bool {
+	return (t.Kind() >= reflect.Int && t.Kind() <= reflect.Uint64) ||
+		a.isFloatingPoint(t) ||
+		a.isComplex(t)
+}
+
+func (a *returnAction) isFloatingPoint(t reflect.Type) bool {
+	return t.Kind() == reflect.Float32 || t.Kind() == reflect.Float64
+}
+
+func (a *returnAction) isComplex(t reflect.Type) bool {
+	return t.Kind() == reflect.Complex64 || t.Kind() == reflect.Complex128
+}
+
+func (a *returnAction) coerceInt(x int64, t reflect.Type) (interface{}, error) {
+	k := t.Kind()
+
+	// Floating point and complex numbers: promote appropriately.
+	if a.isFloatingPoint(t) || a.isComplex(t) {
+		return a.coerceFloat(float64(x), t)
+	}
+
+	// Integers: range check.
+	var min, max int64
+	unsigned := false
+
+	switch k {
+	case reflect.Int8:
+		min = math.MinInt8
+		max = math.MaxInt8
+
+	case reflect.Int16:
+		min = math.MinInt16
+		max = math.MaxInt16
+
+	case reflect.Int32:
+		min = math.MinInt32
+		max = math.MaxInt32
+
+	case reflect.Int64:
+		min = math.MinInt64
+		max = math.MaxInt64
+
+	case reflect.Uint:
+		unsigned = true
+		min = 0
+		max = math.MaxUint32
+
+	case reflect.Uint8:
+		unsigned = true
+		min = 0
+		max = math.MaxUint8
+
+	case reflect.Uint16:
+		unsigned = true
+		min = 0
+		max = math.MaxUint16
+
+	case reflect.Uint32:
+		unsigned = true
+		min = 0
+		max = math.MaxUint32
+
+	case reflect.Uint64:
+		unsigned = true
+		min = 0
+		max = math.MaxInt64
+
+	default:
+		panic(fmt.Sprintf("Unexpected type: %v", t))
+	}
+
+	if x < min || x > max {
+		return nil, errors.New("int value out of range")
+	}
+
+	rv := reflect.New(t).Elem()
+	if unsigned {
+		rv.SetUint(uint64(x))
+	} else {
+		rv.SetInt(x)
+	}
+
+	return rv.Interface(), nil
+}
+
+func (a *returnAction) coerceFloat(x float64, t reflect.Type) (interface{}, error) {
+	// Promote complex numbers.
+	if a.isComplex(t) {
+		return a.coerceComplex(complex(x, 0), t)
+	}
+
+	rv := reflect.New(t).Elem()
+	rv.SetFloat(x)
+	return rv.Interface(), nil
+}
+
+func (a *returnAction) coerceComplex(x complex128, t reflect.Type) (interface{}, error) {
+	rv := reflect.New(t).Elem()
+	rv.SetComplex(x)
+	return rv.Interface(), nil
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/sample/mock_io/mock_io.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/sample/mock_io/mock_io.go
@@ -1,0 +1,71 @@
+// This file was auto-generated using createmock. See the following page for
+// more information:
+//
+//     https://github.com/smartystreets/assertions/internal/oglemock
+//
+
+package mock_io
+
+import (
+	fmt "fmt"
+	oglemock "github.com/smartystreets/assertions/internal/oglemock"
+	io "io"
+	runtime "runtime"
+	unsafe "unsafe"
+)
+
+type MockReader interface {
+	io.Reader
+	oglemock.MockObject
+}
+
+type mockReader struct {
+	controller  oglemock.Controller
+	description string
+}
+
+func NewMockReader(
+	c oglemock.Controller,
+	desc string) MockReader {
+	return &mockReader{
+		controller:  c,
+		description: desc,
+	}
+}
+
+func (m *mockReader) Oglemock_Id() uintptr {
+	return uintptr(unsafe.Pointer(m))
+}
+
+func (m *mockReader) Oglemock_Description() string {
+	return m.description
+}
+
+func (m *mockReader) Read(p0 []uint8) (o0 int, o1 error) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"Read",
+		file,
+		line,
+		[]interface{}{p0})
+
+	if len(retVals) != 2 {
+		panic(fmt.Sprintf("mockReader.Read: invalid return values: %v", retVals))
+	}
+
+	// o0 int
+	if retVals[0] != nil {
+		o0 = retVals[0].(int)
+	}
+
+	// o1 error
+	if retVals[1] != nil {
+		o1 = retVals[1].(error)
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglemock/save_arg.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglemock/save_arg.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglemock
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Create an Action that saves the argument at the given zero-based index to
+// the supplied destination, which must be a pointer to a type that is
+// assignable from the argument type.
+func SaveArg(index int, dst interface{}) Action {
+	return &saveArg{
+		index:      index,
+		dstPointer: dst,
+	}
+}
+
+type saveArg struct {
+	index      int
+	dstPointer interface{}
+
+	// Set by SetSignature.
+	dstValue reflect.Value
+}
+
+func (a *saveArg) SetSignature(signature reflect.Type) (err error) {
+	// Extract the source type.
+	if a.index >= signature.NumIn() {
+		err = fmt.Errorf(
+			"Out of range argument index %v for function type %v",
+			a.index,
+			signature)
+		return
+	}
+
+	srcType := signature.In(a.index)
+
+	// The destination must be a pointer.
+	v := reflect.ValueOf(a.dstPointer)
+	if v.Kind() != reflect.Ptr {
+		err = fmt.Errorf("Destination is %v, not a pointer", v.Kind())
+		return
+	}
+
+	// Dereference the pointer.
+	if v.IsNil() {
+		err = fmt.Errorf("Destination pointer must be non-nil")
+		return
+	}
+
+	a.dstValue = v.Elem()
+
+	// The destination must be assignable from the source.
+	if !srcType.AssignableTo(a.dstValue.Type()) {
+		err = fmt.Errorf(
+			"%v is not assignable to %v",
+			srcType,
+			a.dstValue.Type())
+		return
+	}
+
+	return
+}
+
+func (a *saveArg) Invoke(methodArgs []interface{}) (rets []interface{}) {
+	a.dstValue.Set(reflect.ValueOf(methodArgs[a.index]))
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/assert_aliases.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/assert_aliases.go
@@ -1,0 +1,70 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+// AssertEq(e, a) is equivalent to AssertThat(a, oglematchers.Equals(e)).
+func AssertEq(expected, actual interface{}, errorParts ...interface{}) {
+	assertThat(
+		actual,
+		oglematchers.Equals(expected),
+		1,
+		errorParts)
+}
+
+// AssertNe(e, a) is equivalent to
+// AssertThat(a, oglematchers.Not(oglematchers.Equals(e))).
+func AssertNe(expected, actual interface{}, errorParts ...interface{}) {
+	assertThat(
+		actual,
+		oglematchers.Not(oglematchers.Equals(expected)),
+		1,
+		errorParts)
+}
+
+// AssertLt(x, y) is equivalent to AssertThat(x, oglematchers.LessThan(y)).
+func AssertLt(x, y interface{}, errorParts ...interface{}) {
+	assertThat(x, oglematchers.LessThan(y), 1, errorParts)
+}
+
+// AssertLe(x, y) is equivalent to AssertThat(x, oglematchers.LessOrEqual(y)).
+func AssertLe(x, y interface{}, errorParts ...interface{}) {
+	assertThat(x, oglematchers.LessOrEqual(y), 1, errorParts)
+}
+
+// AssertGt(x, y) is equivalent to AssertThat(x, oglematchers.GreaterThan(y)).
+func AssertGt(x, y interface{}, errorParts ...interface{}) {
+	assertThat(x, oglematchers.GreaterThan(y), 1, errorParts)
+}
+
+// AssertGe(x, y) is equivalent to
+// AssertThat(x, oglematchers.GreaterOrEqual(y)).
+func AssertGe(x, y interface{}, errorParts ...interface{}) {
+	assertThat(x, oglematchers.GreaterOrEqual(y), 1, errorParts)
+}
+
+// AssertTrue(b) is equivalent to AssertThat(b, oglematchers.Equals(true)).
+func AssertTrue(b interface{}, errorParts ...interface{}) {
+	assertThat(b, oglematchers.Equals(true), 1, errorParts)
+}
+
+// AssertFalse(b) is equivalent to AssertThat(b, oglematchers.Equals(false)).
+func AssertFalse(b interface{}, errorParts ...interface{}) {
+	assertThat(b, oglematchers.Equals(false), 1, errorParts)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/assert_that.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/assert_that.go
@@ -1,0 +1,46 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+func assertThat(
+	x interface{},
+	m oglematchers.Matcher,
+	depth int,
+	errorParts []interface{}) {
+	passed := expectThat(x, m, depth+1, errorParts)
+	if !passed {
+		AbortTest()
+	}
+}
+
+// AssertThat is identical to ExpectThat, except that in the event of failure
+// it halts the currently running test immediately. It is thus useful for
+// things like bounds checking:
+//
+//     someSlice := [...]
+//     AssertEq(1, len(someSlice))  // Protects next line from panicking.
+//     ExpectEq("taco", someSlice[0])
+//
+func AssertThat(
+	x interface{},
+	m oglematchers.Matcher,
+	errorParts ...interface{}) {
+	assertThat(x, m, 1, errorParts)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/doc.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/doc.go
@@ -1,0 +1,51 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ogletest provides a framework for writing expressive unit tests. It
+// integrates with the builtin testing package, so it works with the gotest
+// command. Unlike the testing package which offers only basic capabilities for
+// signalling failures, it offers ways to express expectations and get nice
+// failure messages automatically.
+//
+// For example:
+//
+//     ////////////////////////////////////////////////////////////////////////
+//     // testing package test
+//     ////////////////////////////////////////////////////////////////////////
+//
+//     someStr, err := ComputeSomeString()
+//     if err != nil {
+//       t.Errorf("ComputeSomeString: expected nil error, got %v", err)
+//     }
+//
+//     !strings.Contains(someStr, "foo") {
+//       t.Errorf("ComputeSomeString: expected substring foo, got %v", someStr)
+//     }
+//
+//     ////////////////////////////////////////////////////////////////////////
+//     // ogletest test
+//     ////////////////////////////////////////////////////////////////////////
+//
+//     someStr, err := ComputeSomeString()
+//     ExpectEq(nil, err)
+//     ExpectThat(someStr, HasSubstr("foo")
+//
+// Failure messages require no work from the user, and look like the following:
+//
+//     foo_test.go:103:
+//     Expected: has substring "foo"
+//     Actual:   "bar baz"
+//
+package ogletest

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/expect_aliases.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/expect_aliases.go
@@ -1,0 +1,64 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import "github.com/smartystreets/assertions/internal/oglematchers"
+
+// ExpectEq(e, a) is equivalent to ExpectThat(a, oglematchers.Equals(e)).
+func ExpectEq(expected, actual interface{}, errorParts ...interface{}) {
+	expectThat(actual, oglematchers.Equals(expected), 1, errorParts)
+}
+
+// ExpectNe(e, a) is equivalent to
+// ExpectThat(a, oglematchers.Not(oglematchers.Equals(e))).
+func ExpectNe(expected, actual interface{}, errorParts ...interface{}) {
+	expectThat(
+		actual,
+		oglematchers.Not(oglematchers.Equals(expected)),
+		1,
+		errorParts)
+}
+
+// ExpectLt(x, y) is equivalent to ExpectThat(x, oglematchers.LessThan(y)).
+func ExpectLt(x, y interface{}, errorParts ...interface{}) {
+	expectThat(x, oglematchers.LessThan(y), 1, errorParts)
+}
+
+// ExpectLe(x, y) is equivalent to ExpectThat(x, oglematchers.LessOrEqual(y)).
+func ExpectLe(x, y interface{}, errorParts ...interface{}) {
+	expectThat(x, oglematchers.LessOrEqual(y), 1, errorParts)
+}
+
+// ExpectGt(x, y) is equivalent to ExpectThat(x, oglematchers.GreaterThan(y)).
+func ExpectGt(x, y interface{}, errorParts ...interface{}) {
+	expectThat(x, oglematchers.GreaterThan(y), 1, errorParts)
+}
+
+// ExpectGe(x, y) is equivalent to
+// ExpectThat(x, oglematchers.GreaterOrEqual(y)).
+func ExpectGe(x, y interface{}, errorParts ...interface{}) {
+	expectThat(x, oglematchers.GreaterOrEqual(y), 1, errorParts)
+}
+
+// ExpectTrue(b) is equivalent to ExpectThat(b, oglematchers.Equals(true)).
+func ExpectTrue(b interface{}, errorParts ...interface{}) {
+	expectThat(b, oglematchers.Equals(true), 1, errorParts)
+}
+
+// ExpectFalse(b) is equivalent to ExpectThat(b, oglematchers.Equals(false)).
+func ExpectFalse(b interface{}, errorParts ...interface{}) {
+	expectThat(b, oglematchers.Equals(false), 1, errorParts)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/expect_call.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/expect_call.go
@@ -1,0 +1,59 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"github.com/smartystreets/assertions/internal/oglemock"
+	"runtime"
+)
+
+// ExpectCall expresses an expectation that the method of the given name
+// should be called on the supplied mock object. It returns a function that
+// should be called with the expected arguments, matchers for the arguments,
+// or a mix of both.
+//
+// For example:
+//
+//     mockWriter := [...]
+//     ogletest.ExpectCall(mockWriter, "Write")(oglematchers.ElementsAre(0x1))
+//         .WillOnce(oglemock.Return(1, nil))
+//
+// This is a shortcut for calling i.MockController.ExpectCall, where i is the
+// TestInfo struct for the currently-running test. Unlike that direct approach,
+// this function automatically sets the correct file name and line number for
+// the expectation.
+func ExpectCall(o oglemock.MockObject, method string) oglemock.PartialExpecation {
+	// Get information about the call site.
+	_, file, lineNumber, ok := runtime.Caller(1)
+	if !ok {
+		panic("ExpectCall: runtime.Caller")
+	}
+
+	// Grab the current test info.
+	info := currentlyRunningTest
+	if info == nil {
+		panic("ExpectCall: no test info.")
+	}
+
+	// Grab the mock controller.
+	controller := currentlyRunningTest.MockController
+	if controller == nil {
+		panic("ExpectCall: no mock controller.")
+	}
+
+	// Report the expectation.
+	return controller.ExpectCall(o, method, file, lineNumber)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/expect_that.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/expect_that.go
@@ -1,0 +1,100 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"fmt"
+	"path"
+	"reflect"
+	"runtime"
+
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+// ExpectThat confirms that the supplied matcher matches the value x, adding a
+// failure record to the currently running test if it does not. If additional
+// parameters are supplied, the first will be used as a format string for the
+// later ones, and the user-supplied error message will be added to the test
+// output in the event of a failure.
+//
+// For example:
+//
+//     ExpectThat(userName, Equals("jacobsa"))
+//     ExpectThat(users[i], Equals("jacobsa"), "while processing user %d", i)
+//
+func ExpectThat(
+	x interface{},
+	m oglematchers.Matcher,
+	errorParts ...interface{}) {
+	expectThat(x, m, 1, errorParts)
+}
+
+// The generalized form of ExpectThat. depth is the distance on the stack
+// between the caller's frame and the user's frame. Returns passed iff the
+// match succeeded.
+func expectThat(
+	x interface{},
+	m oglematchers.Matcher,
+	depth int,
+	errorParts []interface{}) (passed bool) {
+	// Check whether the value matches. If it does, we are finished.
+	matcherErr := m.Matches(x)
+	if matcherErr == nil {
+		passed = true
+		return
+	}
+
+	var r FailureRecord
+
+	// Get information about the call site.
+	var ok bool
+	if _, r.FileName, r.LineNumber, ok = runtime.Caller(depth + 1); !ok {
+		panic("expectThat: runtime.Caller")
+	}
+
+	r.FileName = path.Base(r.FileName)
+
+	// Create an appropriate failure message. Make sure that the expected and
+	// actual values align properly.
+	relativeClause := ""
+	if matcherErr.Error() != "" {
+		relativeClause = fmt.Sprintf(", %s", matcherErr.Error())
+	}
+
+	r.Error = fmt.Sprintf(
+		"Expected: %s\nActual:   %v%s",
+		m.Description(),
+		x,
+		relativeClause)
+
+	// Add the user error, if any.
+	if len(errorParts) != 0 {
+		v := reflect.ValueOf(errorParts[0])
+		if v.Kind() != reflect.String {
+			panic(fmt.Sprintf("ExpectThat: invalid format string type %v", v.Kind()))
+		}
+
+		r.Error = fmt.Sprintf(
+			"%s\n%s",
+			r.Error,
+			fmt.Sprintf(v.String(), errorParts[1:]...))
+	}
+
+	// Report the failure.
+	AddFailureRecord(r)
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/failure.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/failure.go
@@ -1,0 +1,90 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"fmt"
+	"path"
+	"runtime"
+)
+
+// FailureRecord represents a single failed expectation or assertion for a
+// test. Most users don't want to interact with these directly; they are
+// generated implicitly using ExpectThat, AssertThat, ExpectLt, etc.
+type FailureRecord struct {
+	// The file name within which the expectation failed, e.g. "foo_test.go".
+	FileName string
+
+	// The line number at which the expectation failed.
+	LineNumber int
+
+	// The error associated with the file:line pair above. For example, the
+	// following expectation:
+	//
+	//     ExpectEq(17, "taco")"
+	//
+	// May cause this error:
+	//
+	//     Expected: 17
+	//     Actual:   "taco", which is not numeric
+	//
+	Error string
+}
+
+// Record a failure for the currently running test (and continue running it).
+// Most users will want to use ExpectThat, ExpectEq, etc. instead of this
+// function. Those that do want to report arbitrary errors will probably be
+// satisfied with AddFailure, which is easier to use.
+func AddFailureRecord(r FailureRecord) {
+	currentlyRunningTest.mu.Lock()
+	defer currentlyRunningTest.mu.Unlock()
+
+	currentlyRunningTest.failureRecords = append(
+		currentlyRunningTest.failureRecords,
+		r)
+}
+
+// Call AddFailureRecord with a record whose file name and line number come
+// from the caller of this function, and whose error string is created by
+// calling fmt.Sprintf using the arguments to this function.
+func AddFailure(format string, a ...interface{}) {
+	r := FailureRecord{
+		Error: fmt.Sprintf(format, a...),
+	}
+
+	// Get information about the call site.
+	var ok bool
+	if _, r.FileName, r.LineNumber, ok = runtime.Caller(1); !ok {
+		panic("Can't find caller")
+	}
+
+	r.FileName = path.Base(r.FileName)
+
+	AddFailureRecord(r)
+}
+
+// A sentinel type that is used in a conspiracy between AbortTest and runTests.
+// If runTests sees an abortError as the value given to a panic() call, it will
+// avoid printing the panic error.
+type abortError struct {
+}
+
+// Immediately stop executing the running test, causing it to fail with the
+// failures previously recorded. Behavior is undefined if no failures have been
+// recorded.
+func AbortTest() {
+	panic(abortError{})
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/register.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/register.go
@@ -1,0 +1,86 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+// The input to ogletest.Register. Most users will want to use
+// ogletest.RegisterTestSuite.
+//
+// A test suite is the basic unit of registration in ogletest. It consists of
+// zero or more named test functions which will be run in sequence, along with
+// optional setup and tear-down functions.
+type TestSuite struct {
+	// The name of the overall suite, e.g. "MyPackageTest".
+	Name string
+
+	// If non-nil, a function that will be run exactly once, before any of the
+	// test functions are run.
+	SetUp func()
+
+	// The test functions comprising this suite.
+	TestFunctions []TestFunction
+
+	// If non-nil, a function that will be run exactly once, after all of the
+	// test functions have run.
+	TearDown func()
+}
+
+type TestFunction struct {
+	// The name of this test function, relative to the suite in which it resides.
+	// If the name is "TweaksFrobnicator", then the function might be presented
+	// in the ogletest UI as "FooTest.TweaksFrobnicator".
+	Name string
+
+	// If non-nil, a function that is run before Run, passed a pointer to a
+	// struct containing information about the test run.
+	SetUp func(*TestInfo)
+
+	// The function to invoke for the test body. Must be non-nil. Will not be run
+	// if SetUp panics.
+	Run func()
+
+	// If non-nil, a function that is run after Run.
+	TearDown func()
+}
+
+// Register a test suite for execution by RunTests.
+//
+// This is the most general registration mechanism. Most users will want
+// RegisterTestSuite, which is a wrapper around this function that requires
+// less boilerplate.
+//
+// Panics on invalid input.
+func Register(suite TestSuite) {
+	// Make sure the suite is legal.
+	if suite.Name == "" {
+		panic("Test suites must have names.")
+	}
+
+	for _, tf := range suite.TestFunctions {
+		if tf.Name == "" {
+			panic("Test functions must have names.")
+		}
+
+		if tf.Run == nil {
+			panic("Test functions must have non-nil run fields.")
+		}
+	}
+
+	// Save the suite for later.
+	registeredSuites = append(registeredSuites, suite)
+}
+
+// The list of test suites previously registered.
+var registeredSuites []TestSuite

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/register_test_suite.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/register_test_suite.go
@@ -1,0 +1,193 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/smartystreets/assertions/internal/ogletest/srcutil"
+)
+
+// Test suites that implement this interface have special meaning to
+// RegisterTestSuite.
+type SetUpTestSuiteInterface interface {
+	// This method will be called exactly once, before the first test method is
+	// run. The receiver of this method will be a zero value of the test suite
+	// type, and is not shared with any other methods. Use this method to set up
+	// any necessary global state shared by all of the test methods.
+	SetUpTestSuite()
+}
+
+// Test suites that implement this interface have special meaning to
+// RegisterTestSuite.
+type TearDownTestSuiteInterface interface {
+	// This method will be called exactly once, after the last test method is
+	// run. The receiver of this method will be a zero value of the test suite
+	// type, and is not shared with any other methods. Use this method to clean
+	// up after any necessary global state shared by all of the test methods.
+	TearDownTestSuite()
+}
+
+// Test suites that implement this interface have special meaning to
+// Register.
+type SetUpInterface interface {
+	// This method is called before each test method is invoked, with the same
+	// receiver as that test method. At the time this method is invoked, the
+	// receiver is a zero value for the test suite type. Use this method for
+	// common setup code that works on data not shared across tests.
+	SetUp(*TestInfo)
+}
+
+// Test suites that implement this interface have special meaning to
+// Register.
+type TearDownInterface interface {
+	// This method is called after each test method is invoked, with the same
+	// receiver as that test method. Use this method for common cleanup code that
+	// works on data not shared across tests.
+	TearDown()
+}
+
+// RegisterTestSuite tells ogletest about a test suite containing tests that it
+// should run. Any exported method on the type pointed to by the supplied
+// prototype value will be treated as test methods, with the exception of the
+// methods defined by the following interfaces, which when present are treated
+// as described in the documentation for those interfaces:
+//
+//  *  SetUpTestSuiteInterface
+//  *  SetUpInterface
+//  *  TearDownInterface
+//  *  TearDownTestSuiteInterface
+//
+// Each test method is invoked on a different receiver, which is initially a
+// zero value of the test suite type.
+//
+// Example:
+//
+//     // Some value that is needed by the tests but is expensive to compute.
+//     var someExpensiveThing uint
+//
+//     type FooTest struct {
+//       // Path to a temporary file used by the tests. Each test gets a
+//       // different temporary file.
+//       tempFile string
+//     }
+//     func init() { ogletest.RegisterTestSuite(&FooTest{}) }
+//
+//     func (t *FooTest) SetUpTestSuite() {
+//       someExpensiveThing = ComputeSomeExpensiveThing()
+//     }
+//
+//     func (t *FooTest) SetUp(ti *ogletest.TestInfo) {
+//       t.tempFile = CreateTempFile()
+//     }
+//
+//     func (t *FooTest) TearDown() {
+//       DeleteTempFile(t.tempFile)
+//     }
+//
+//     func (t *FooTest) FrobinicatorIsSuccessfullyTweaked() {
+//       res := DoSomethingWithExpensiveThing(someExpensiveThing, t.tempFile)
+//       ExpectThat(res, Equals(true))
+//     }
+//
+func RegisterTestSuite(p interface{}) {
+	if p == nil {
+		panic("RegisterTestSuite called with nil suite.")
+	}
+
+	val := reflect.ValueOf(p)
+	typ := val.Type()
+	var zeroInstance reflect.Value
+
+	// We will transform to a TestSuite struct.
+	suite := TestSuite{}
+	suite.Name = typ.Elem().Name()
+
+	zeroInstance = reflect.New(typ.Elem())
+	if i, ok := zeroInstance.Interface().(SetUpTestSuiteInterface); ok {
+		suite.SetUp = func() { i.SetUpTestSuite() }
+	}
+
+	zeroInstance = reflect.New(typ.Elem())
+	if i, ok := zeroInstance.Interface().(TearDownTestSuiteInterface); ok {
+		suite.TearDown = func() { i.TearDownTestSuite() }
+	}
+
+	// Transform a list of test methods for the suite, filtering them to just the
+	// ones that we don't need to skip.
+	for _, method := range filterMethods(suite.Name, srcutil.GetMethodsInSourceOrder(typ)) {
+		var tf TestFunction
+		tf.Name = method.Name
+
+		// Create an instance to be operated on by all of the TestFunction's
+		// internal functions.
+		instance := reflect.New(typ.Elem())
+
+		// Bind the functions to the instance.
+		if i, ok := instance.Interface().(SetUpInterface); ok {
+			tf.SetUp = func(ti *TestInfo) { i.SetUp(ti) }
+		}
+
+		methodCopy := method
+		tf.Run = func() { runTestMethod(instance, methodCopy) }
+
+		if i, ok := instance.Interface().(TearDownInterface); ok {
+			tf.TearDown = func() { i.TearDown() }
+		}
+
+		// Save the TestFunction.
+		suite.TestFunctions = append(suite.TestFunctions, tf)
+	}
+
+	// Register the suite.
+	Register(suite)
+}
+
+func runTestMethod(suite reflect.Value, method reflect.Method) {
+	if method.Func.Type().NumIn() != 1 {
+		panic(fmt.Sprintf(
+			"%s: expected 1 args, actually %d.",
+			method.Name,
+			method.Func.Type().NumIn()))
+	}
+
+	method.Func.Call([]reflect.Value{suite})
+}
+
+func filterMethods(suiteName string, in []reflect.Method) (out []reflect.Method) {
+	for _, m := range in {
+		// Skip set up, tear down, and unexported methods.
+		if isSpecialMethod(m.Name) || !isExportedMethod(m.Name) {
+			continue
+		}
+
+		out = append(out, m)
+	}
+
+	return
+}
+
+func isSpecialMethod(name string) bool {
+	return (name == "SetUpTestSuite") ||
+		(name == "TearDownTestSuite") ||
+		(name == "SetUp") ||
+		(name == "TearDown")
+}
+
+func isExportedMethod(name string) bool {
+	return len(name) > 0 && name[0] >= 'A' && name[0] <= 'Z'
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/run_tests.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/run_tests.go
@@ -1,0 +1,354 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions/internal/reqtrace"
+)
+
+var fTestFilter = flag.String(
+	"ogletest.run",
+	"",
+	"Regexp for matching tests to run.")
+
+var fStopEarly = flag.Bool(
+	"ogletest.stop_early",
+	false,
+	"If true, stop after the first failure.")
+
+// runTestsOnce protects RunTests from executing multiple times.
+var runTestsOnce sync.Once
+
+func isAbortError(x interface{}) bool {
+	_, ok := x.(abortError)
+	return ok
+}
+
+// Run a single test function, returning a slice of failure records.
+func runTestFunction(tf TestFunction) (failures []FailureRecord) {
+	// Set up a clean slate for this test. Make sure to reset it after everything
+	// below is finished, so we don't accidentally use it elsewhere.
+	currentlyRunningTest = newTestInfo()
+	defer func() {
+		currentlyRunningTest = nil
+	}()
+
+	ti := currentlyRunningTest
+
+	// Start a trace.
+	var reportOutcome reqtrace.ReportFunc
+	ti.Ctx, reportOutcome = reqtrace.Trace(ti.Ctx, tf.Name)
+
+	// Run the SetUp function, if any, paying attention to whether it panics.
+	setUpPanicked := false
+	if tf.SetUp != nil {
+		setUpPanicked = runWithProtection(func() { tf.SetUp(ti) })
+	}
+
+	// Run the test function itself, but only if the SetUp function didn't panic.
+	// (This includes AssertThat errors.)
+	if !setUpPanicked {
+		runWithProtection(tf.Run)
+	}
+
+	// Run the TearDown function, if any.
+	if tf.TearDown != nil {
+		runWithProtection(tf.TearDown)
+	}
+
+	// Tell the mock controller for the tests to report any errors it's sitting
+	// on.
+	ti.MockController.Finish()
+
+	// Report the outcome to reqtrace.
+	if len(ti.failureRecords) == 0 {
+		reportOutcome(nil)
+	} else {
+		reportOutcome(fmt.Errorf("%v failure records", len(ti.failureRecords)))
+	}
+
+	return ti.failureRecords
+}
+
+// Run everything registered with Register (including via the wrapper
+// RegisterTestSuite).
+//
+// Failures are communicated to the supplied testing.T object. This is the
+// bridge between ogletest and the testing package (and `go test`); you should
+// ensure that it's called at least once by creating a test function compatible
+// with `go test` and calling it there.
+//
+// For example:
+//
+//     import (
+//       "github.com/smartystreets/assertions/internal/ogletest"
+//       "testing"
+//     )
+//
+//     func TestOgletest(t *testing.T) {
+//       ogletest.RunTests(t)
+//     }
+//
+func RunTests(t *testing.T) {
+	runTestsOnce.Do(func() { runTestsInternal(t) })
+}
+
+// Signalling between RunTests and StopRunningTests.
+var gStopRunning uint64
+
+// Request that RunTests stop what it's doing. After the currently running test
+// is finished, including tear-down, the program will exit with an error code.
+func StopRunningTests() {
+	atomic.StoreUint64(&gStopRunning, 1)
+}
+
+// runTestsInternal does the real work of RunTests, which simply wraps it in a
+// sync.Once.
+func runTestsInternal(t *testing.T) {
+	// Process each registered suite.
+	for _, suite := range registeredSuites {
+		// Stop now if we've already seen a failure and we've been told to stop
+		// early.
+		if t.Failed() && *fStopEarly {
+			break
+		}
+
+		// Print a banner.
+		fmt.Printf("[----------] Running tests from %s\n", suite.Name)
+
+		// Run the SetUp function, if any.
+		if suite.SetUp != nil {
+			suite.SetUp()
+		}
+
+		// Run each test function that the user has not told us to skip.
+		stoppedEarly := false
+		for _, tf := range filterTestFunctions(suite) {
+			// Did the user request that we stop running tests? If so, skip the rest
+			// of this suite (and exit after tearing it down).
+			if atomic.LoadUint64(&gStopRunning) != 0 {
+				stoppedEarly = true
+				break
+			}
+
+			// Print a banner for the start of this test function.
+			fmt.Printf("[ RUN      ] %s.%s\n", suite.Name, tf.Name)
+
+			// Run the test function.
+			startTime := time.Now()
+			failures := runTestFunction(tf)
+			runDuration := time.Since(startTime)
+
+			// Print any failures, and mark the test as having failed if there are any.
+			for _, record := range failures {
+				t.Fail()
+				fmt.Printf(
+					"%s:%d:\n%s\n\n",
+					record.FileName,
+					record.LineNumber,
+					record.Error)
+			}
+
+			// Print a banner for the end of the test.
+			bannerMessage := "[       OK ]"
+			if len(failures) != 0 {
+				bannerMessage = "[  FAILED  ]"
+			}
+
+			// Print a summary of the time taken, if long enough.
+			var timeMessage string
+			if runDuration >= 25*time.Millisecond {
+				timeMessage = fmt.Sprintf(" (%s)", runDuration.String())
+			}
+
+			fmt.Printf(
+				"%s %s.%s%s\n",
+				bannerMessage,
+				suite.Name,
+				tf.Name,
+				timeMessage)
+
+			// Stop running tests from this suite if we've been told to stop early
+			// and this test failed.
+			if t.Failed() && *fStopEarly {
+				break
+			}
+		}
+
+		// Run the suite's TearDown function, if any.
+		if suite.TearDown != nil {
+			suite.TearDown()
+		}
+
+		// Were we told to exit early?
+		if stoppedEarly {
+			fmt.Println("Exiting early due to user request.")
+			os.Exit(1)
+		}
+
+		fmt.Printf("[----------] Finished with tests from %s\n", suite.Name)
+	}
+}
+
+// Return true iff the supplied program counter appears to lie within panic().
+func isPanic(pc uintptr) bool {
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return false
+	}
+
+	return f.Name() == "runtime.gopanic" || f.Name() == "runtime.sigpanic"
+}
+
+// Find the deepest stack frame containing something that appears to be a
+// panic. Return the 'skip' value that a caller to this function would need
+// to supply to runtime.Caller for that frame, or a negative number if not found.
+func findPanic() int {
+	localSkip := -1
+	for i := 0; ; i++ {
+		// Stop if we've passed the base of the stack.
+		pc, _, _, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+
+		// Is this a panic?
+		if isPanic(pc) {
+			localSkip = i
+		}
+	}
+
+	return localSkip - 1
+}
+
+// Attempt to find the file base name and line number for the ultimate source
+// of a panic, on the panicking stack. Return a human-readable sentinel if
+// unsuccessful.
+func findPanicFileLine() (string, int) {
+	panicSkip := findPanic()
+	if panicSkip < 0 {
+		return "(unknown)", 0
+	}
+
+	// Find the trigger of the panic.
+	_, file, line, ok := runtime.Caller(panicSkip + 1)
+	if !ok {
+		return "(unknown)", 0
+	}
+
+	return path.Base(file), line
+}
+
+// Run the supplied function, catching panics (including AssertThat errors) and
+// reporting them to the currently-running test as appropriate. Return true iff
+// the function panicked.
+func runWithProtection(f func()) (panicked bool) {
+	defer func() {
+		// If the test didn't panic, we're done.
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		panicked = true
+
+		// We modify the currently running test below.
+		currentlyRunningTest.mu.Lock()
+		defer currentlyRunningTest.mu.Unlock()
+
+		// If the function panicked (and the panic was not due to an AssertThat
+		// failure), add a failure for the panic.
+		if !isAbortError(r) {
+			var panicRecord FailureRecord
+			panicRecord.FileName, panicRecord.LineNumber = findPanicFileLine()
+			panicRecord.Error = fmt.Sprintf(
+				"panic: %v\n\n%s", r, formatPanicStack())
+
+			currentlyRunningTest.failureRecords = append(
+				currentlyRunningTest.failureRecords,
+				panicRecord)
+		}
+	}()
+
+	f()
+	return
+}
+
+func formatPanicStack() string {
+	buf := new(bytes.Buffer)
+
+	// Find the panic. If successful, we'll skip to below it. Otherwise, we'll
+	// format everything.
+	var initialSkip int
+	if panicSkip := findPanic(); panicSkip >= 0 {
+		initialSkip = panicSkip + 1
+	}
+
+	for i := initialSkip; ; i++ {
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+
+		// Choose a function name to display.
+		funcName := "(unknown)"
+		if f := runtime.FuncForPC(pc); f != nil {
+			funcName = f.Name()
+		}
+
+		// Stop if we've gotten as far as the test runner code.
+		if funcName == "github.com/smartystreets/assertions/internal/ogletest.runTestMethod" ||
+			funcName == "github.com/smartystreets/assertions/internal/ogletest.runWithProtection" {
+			break
+		}
+
+		// Add an entry for this frame.
+		fmt.Fprintf(buf, "%s\n\t%s:%d\n", funcName, file, line)
+	}
+
+	return buf.String()
+}
+
+// Filter test functions according to the user-supplied filter flag.
+func filterTestFunctions(suite TestSuite) (out []TestFunction) {
+	re, err := regexp.Compile(*fTestFilter)
+	if err != nil {
+		panic("Invalid value for --ogletest.run: " + err.Error())
+	}
+
+	for _, tf := range suite.TestFunctions {
+		fullName := fmt.Sprintf("%s.%s", suite.Name, tf.Name)
+		if !re.MatchString(fullName) {
+			continue
+		}
+
+		out = append(out, tf)
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/srcutil/docs.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/srcutil/docs.go
@@ -1,0 +1,5 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+
+// Functions for working with source code.
+package srcutil

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/srcutil/methods.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/srcutil/methods.go
@@ -1,0 +1,65 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package srcutil
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"sort"
+)
+
+func getLine(m reflect.Method) int {
+	pc := m.Func.Pointer()
+
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		panic(fmt.Sprintf("Couldn't get runtime func for method (pc=%d): %v", pc, m))
+	}
+
+	_, line := f.FileLine(pc)
+	return line
+}
+
+type sortableMethodSet []reflect.Method
+
+func (s sortableMethodSet) Len() int {
+	return len(s)
+}
+
+func (s sortableMethodSet) Less(i, j int) bool {
+	return getLine(s[i]) < getLine(s[j])
+}
+
+func (s sortableMethodSet) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Given a type t, return all of the methods of t sorted such that source file
+// order is preserved. Order across files is undefined. Order within lines is
+// undefined.
+func GetMethodsInSourceOrder(t reflect.Type) []reflect.Method {
+	// Build the list of methods.
+	methods := sortableMethodSet{}
+	for i := 0; i < t.NumMethod(); i++ {
+		methods = append(methods, t.Method(i))
+	}
+
+	// Sort it.
+	sort.Sort(methods)
+
+	return methods
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/failing.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/failing.test.go
@@ -1,0 +1,252 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/assertions/internal/oglematchers"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+)
+
+func TestFailingTest(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Usual failures
+////////////////////////////////////////////////////////////////////////
+
+type FailingTest struct {
+}
+
+var _ TearDownInterface = &FailingTest{}
+var _ TearDownTestSuiteInterface = &FailingTest{}
+
+func init() { RegisterTestSuite(&FailingTest{}) }
+
+func (t *FailingTest) TearDown() {
+	fmt.Println("TearDown running.")
+}
+
+func (t *FailingTest) TearDownTestSuite() {
+	fmt.Println("TearDownTestSuite running.")
+}
+
+func (t *FailingTest) PassingMethod() {
+}
+
+func (t *FailingTest) Equals() {
+	ExpectThat(17, Equals(17.5))
+	ExpectThat(17, Equals("taco"))
+}
+
+func (t *FailingTest) LessThan() {
+	ExpectThat(18, LessThan(17))
+	ExpectThat(18, LessThan("taco"))
+}
+
+func (t *FailingTest) HasSubstr() {
+	ExpectThat("taco", HasSubstr("ac"))
+	ExpectThat(17, HasSubstr("ac"))
+}
+
+func (t *FailingTest) ExpectWithUserErrorMessages() {
+	ExpectThat(17, Equals(19), "foo bar: %d", 112)
+	ExpectEq(17, 17.5, "foo bar: %d", 112)
+	ExpectLe(17, 16.9, "foo bar: %d", 112)
+	ExpectLt(17, 16.9, "foo bar: %d", 112)
+	ExpectGe(17, 17.1, "foo bar: %d", 112)
+	ExpectGt(17, "taco", "foo bar: %d", 112)
+	ExpectNe(17, 17.0, "foo bar: %d", 112)
+	ExpectFalse(true, "foo bar: %d", 112)
+	ExpectTrue(false, "foo bar: %d", 112)
+}
+
+func (t *FailingTest) AssertWithUserErrorMessages() {
+	AssertThat(17, Equals(19), "foo bar: %d", 112)
+}
+
+func (t *FailingTest) ExpectationAliases() {
+	ExpectEq(17, 17.5)
+	ExpectEq("taco", 17.5)
+
+	ExpectLe(17, 16.9)
+	ExpectLt(17, 16.9)
+	ExpectLt(17, "taco")
+
+	ExpectGe(17, 17.1)
+	ExpectGt(17, 17.1)
+	ExpectGt(17, "taco")
+
+	ExpectNe(17, 17.0)
+	ExpectNe(17, "taco")
+
+	ExpectFalse(true)
+	ExpectFalse("taco")
+
+	ExpectTrue(false)
+	ExpectTrue("taco")
+}
+
+func (t *FailingTest) AssertThatFailure() {
+	AssertThat(17, Equals(19))
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertEqFailure() {
+	AssertEq(19, 17)
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertNeFailure() {
+	AssertNe(19, 19)
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertLeFailure() {
+	AssertLe(19, 17)
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertLtFailure() {
+	AssertLt(19, 17)
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertGeFailure() {
+	AssertGe(17, 19)
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertGtFailure() {
+	AssertGt(17, 19)
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertTrueFailure() {
+	AssertTrue("taco")
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AssertFalseFailure() {
+	AssertFalse("taco")
+	panic("Shouldn't get here.")
+}
+
+func (t *FailingTest) AddFailureRecord() {
+	r := FailureRecord{
+		FileName:   "foo.go",
+		LineNumber: 17,
+		Error:      "taco\nburrito",
+	}
+
+	AddFailureRecord(r)
+}
+
+func (t *FailingTest) AddFailure() {
+	AddFailure("taco")
+	AddFailure("burrito: %d", 17)
+}
+
+func (t *FailingTest) AddFailureThenAbortTest() {
+	AddFailure("enchilada")
+	AbortTest()
+	fmt.Println("Shouldn't get here.")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Expectation failure during SetUp
+////////////////////////////////////////////////////////////////////////
+
+type ExpectFailDuringSetUpTest struct {
+}
+
+func init() { RegisterTestSuite(&ExpectFailDuringSetUpTest{}) }
+
+func (t *ExpectFailDuringSetUpTest) SetUp(i *TestInfo) {
+	ExpectFalse(true)
+}
+
+func (t *ExpectFailDuringSetUpTest) TearDown() {
+	fmt.Println("TearDown running.")
+}
+
+func (t *ExpectFailDuringSetUpTest) PassingMethod() {
+	fmt.Println("Method running.")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Assertion failure during SetUp
+////////////////////////////////////////////////////////////////////////
+
+type AssertFailDuringSetUpTest struct {
+}
+
+func init() { RegisterTestSuite(&AssertFailDuringSetUpTest{}) }
+
+func (t *AssertFailDuringSetUpTest) SetUp(i *TestInfo) {
+	AssertFalse(true)
+}
+
+func (t *AssertFailDuringSetUpTest) TearDown() {
+	fmt.Println("TearDown running.")
+}
+
+func (t *AssertFailDuringSetUpTest) PassingMethod() {
+	fmt.Println("Method running.")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Expectation failure during TearDown
+////////////////////////////////////////////////////////////////////////
+
+type ExpectFailDuringTearDownTest struct {
+}
+
+func init() { RegisterTestSuite(&ExpectFailDuringTearDownTest{}) }
+
+func (t *ExpectFailDuringTearDownTest) SetUp(i *TestInfo) {
+	fmt.Println("SetUp running.")
+}
+
+func (t *ExpectFailDuringTearDownTest) TearDown() {
+	ExpectFalse(true)
+}
+
+func (t *ExpectFailDuringTearDownTest) PassingMethod() {
+	fmt.Println("Method running.")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Assertion failure during TearDown
+////////////////////////////////////////////////////////////////////////
+
+type AssertFailDuringTearDownTest struct {
+}
+
+func init() { RegisterTestSuite(&AssertFailDuringTearDownTest{}) }
+
+func (t *AssertFailDuringTearDownTest) SetUp(i *TestInfo) {
+	fmt.Println("SetUp running.")
+}
+
+func (t *AssertFailDuringTearDownTest) TearDown() {
+	AssertFalse(true)
+}
+
+func (t *AssertFailDuringTearDownTest) PassingMethod() {
+	fmt.Println("Method running.")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/filtered.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/filtered.test.go
@@ -1,0 +1,79 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	"fmt"
+	. "github.com/smartystreets/assertions/internal/oglematchers"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+	"testing"
+)
+
+func TestFiltered(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Partially filtered out
+////////////////////////////////////////////////////////////////////////
+
+type PartiallyFilteredTest struct {
+}
+
+func init() { RegisterTestSuite(&PartiallyFilteredTest{}) }
+
+func (t *PartiallyFilteredTest) PassingTestFoo() {
+	ExpectThat(19, Equals(19))
+}
+
+func (t *PartiallyFilteredTest) PassingTestBar() {
+	ExpectThat(17, Equals(17))
+}
+
+func (t *PartiallyFilteredTest) PartiallyFilteredTestFoo() {
+	ExpectThat(18, LessThan(17))
+}
+
+func (t *PartiallyFilteredTest) PartiallyFilteredTestBar() {
+	ExpectThat("taco", HasSubstr("blah"))
+}
+
+func (t *PartiallyFilteredTest) PartiallyFilteredTestBaz() {
+	ExpectThat(18, LessThan(17))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Completely filtered out
+////////////////////////////////////////////////////////////////////////
+
+type CompletelyFilteredTest struct {
+}
+
+func init() { RegisterTestSuite(&CompletelyFilteredTest{}) }
+
+func (t *CompletelyFilteredTest) SetUpTestSuite() {
+	fmt.Println("SetUpTestSuite run!")
+}
+
+func (t *CompletelyFilteredTest) TearDownTestSuite() {
+	fmt.Println("TearDownTestSuite run!")
+}
+
+func (t *PartiallyFilteredTest) SomePassingTest() {
+	ExpectThat(19, Equals(19))
+}
+
+func (t *PartiallyFilteredTest) SomeFailingTest() {
+	ExpectThat(19, Equals(17))
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/mock.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/mock.test.go
@@ -1,0 +1,82 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	. "github.com/smartystreets/assertions/internal/oglematchers"
+	"github.com/smartystreets/assertions/internal/oglemock"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+	"github.com/smartystreets/assertions/internal/ogletest/test_cases/mock_image"
+	"image/color"
+	"testing"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+type MockTest struct {
+	controller oglemock.Controller
+	image      mock_image.MockImage
+}
+
+func init()                     { RegisterTestSuite(&MockTest{}) }
+func TestMockTest(t *testing.T) { RunTests(t) }
+
+func (t *MockTest) SetUp(i *TestInfo) {
+	t.controller = i.MockController
+	t.image = mock_image.NewMockImage(t.controller, "some mock image")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *MockTest) ExpectationSatisfied() {
+	ExpectCall(t.image, "At")(11, GreaterThan(19)).
+		WillOnce(oglemock.Return(color.Gray{0}))
+
+	ExpectThat(t.image.At(11, 23), IdenticalTo(color.Gray{0}))
+}
+
+func (t *MockTest) MockExpectationNotSatisfied() {
+	ExpectCall(t.image, "At")(11, GreaterThan(19)).
+		WillOnce(oglemock.Return(color.Gray{0}))
+}
+
+func (t *MockTest) ExpectCallForUnknownMethod() {
+	ExpectCall(t.image, "FooBar")(11)
+}
+
+func (t *MockTest) UnexpectedCall() {
+	t.image.At(11, 23)
+}
+
+func (t *MockTest) InvokeFunction() {
+	var suppliedX, suppliedY int
+	f := func(x, y int) color.Color {
+		suppliedX = x
+		suppliedY = y
+		return color.Gray{17}
+	}
+
+	ExpectCall(t.image, "At")(Any(), Any()).
+		WillOnce(oglemock.Invoke(f))
+
+	ExpectThat(t.image.At(-1, 12), IdenticalTo(color.Gray{17}))
+	ExpectEq(-1, suppliedX)
+	ExpectEq(12, suppliedY)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/mock_image/mock_image.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/mock_image/mock_image.go
@@ -1,0 +1,115 @@
+// This file was auto-generated using createmock. See the following page for
+// more information:
+//
+//     https://github.com/smartystreets/assertions/internal/oglemock
+//
+
+package mock_image
+
+import (
+	fmt "fmt"
+	oglemock "github.com/smartystreets/assertions/internal/oglemock"
+	image "image"
+	color "image/color"
+	runtime "runtime"
+	unsafe "unsafe"
+)
+
+type MockImage interface {
+	image.Image
+	oglemock.MockObject
+}
+
+type mockImage struct {
+	controller  oglemock.Controller
+	description string
+}
+
+func NewMockImage(
+	c oglemock.Controller,
+	desc string) MockImage {
+	return &mockImage{
+		controller:  c,
+		description: desc,
+	}
+}
+
+func (m *mockImage) Oglemock_Id() uintptr {
+	return uintptr(unsafe.Pointer(m))
+}
+
+func (m *mockImage) Oglemock_Description() string {
+	return m.description
+}
+
+func (m *mockImage) At(p0 int, p1 int) (o0 color.Color) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"At",
+		file,
+		line,
+		[]interface{}{p0, p1})
+
+	if len(retVals) != 1 {
+		panic(fmt.Sprintf("mockImage.At: invalid return values: %v", retVals))
+	}
+
+	// o0 color.Color
+	if retVals[0] != nil {
+		o0 = retVals[0].(color.Color)
+	}
+
+	return
+}
+
+func (m *mockImage) Bounds() (o0 image.Rectangle) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"Bounds",
+		file,
+		line,
+		[]interface{}{})
+
+	if len(retVals) != 1 {
+		panic(fmt.Sprintf("mockImage.Bounds: invalid return values: %v", retVals))
+	}
+
+	// o0 image.Rectangle
+	if retVals[0] != nil {
+		o0 = retVals[0].(image.Rectangle)
+	}
+
+	return
+}
+
+func (m *mockImage) ColorModel() (o0 color.Model) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"ColorModel",
+		file,
+		line,
+		[]interface{}{})
+
+	if len(retVals) != 1 {
+		panic(fmt.Sprintf("mockImage.ColorModel: invalid return values: %v", retVals))
+	}
+
+	// o0 color.Model
+	if retVals[0] != nil {
+		o0 = retVals[0].(color.Model)
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/no_cases.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/no_cases.test.go
@@ -1,0 +1,41 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	"fmt"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+	"testing"
+)
+
+func TestNoCases(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+type NoCasesTest struct {
+}
+
+func init() { RegisterTestSuite(&NoCasesTest{}) }
+
+func (t *NoCasesTest) SetUpTestSuite() {
+	fmt.Println("SetUpTestSuite run!")
+}
+
+func (t *NoCasesTest) TearDownTestSuite() {
+	fmt.Println("TearDownTestSuite run!")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/panicking.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/panicking.test.go
@@ -1,0 +1,99 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	. "github.com/smartystreets/assertions/internal/oglematchers"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+)
+
+func TestPanickingTest(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// PanickingTest
+////////////////////////////////////////////////////////////////////////
+
+func someFuncThatPanics() {
+	panic("Panic in someFuncThatPanics")
+}
+
+type PanickingTest struct {
+}
+
+func init() { RegisterTestSuite(&PanickingTest{}) }
+
+func (t *PanickingTest) TearDown() {
+	fmt.Println("TearDown running.")
+}
+
+func (t *PanickingTest) ExplicitPanic() {
+	panic("Panic in ExplicitPanic")
+}
+
+func (t *PanickingTest) ExplicitPanicInHelperFunction() {
+	someFuncThatPanics()
+}
+
+func (t *PanickingTest) NilPointerDerefence() {
+	var p *int
+	log.Println(*p)
+}
+
+func (t *PanickingTest) ZzzSomeOtherTest() {
+	ExpectThat(17, Equals(17.0))
+}
+
+////////////////////////////////////////////////////////////////////////
+// SetUpPanicTest
+////////////////////////////////////////////////////////////////////////
+
+type SetUpPanicTest struct {
+}
+
+func init() { RegisterTestSuite(&SetUpPanicTest{}) }
+
+func (t *SetUpPanicTest) SetUp(ti *TestInfo) {
+	fmt.Println("SetUp about to panic.")
+	panic("Panic in SetUp")
+}
+
+func (t *SetUpPanicTest) TearDown() {
+	fmt.Println("TearDown running.")
+}
+
+func (t *SetUpPanicTest) SomeTestCase() {
+}
+
+////////////////////////////////////////////////////////////////////////
+// TearDownPanicTest
+////////////////////////////////////////////////////////////////////////
+
+type TearDownPanicTest struct {
+}
+
+func init() { RegisterTestSuite(&TearDownPanicTest{}) }
+
+func (t *TearDownPanicTest) TearDown() {
+	fmt.Println("TearDown about to panic.")
+	panic("Panic in TearDown")
+}
+
+func (t *TearDownPanicTest) SomeTestCase() {
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/passing.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/passing.test.go
@@ -1,0 +1,120 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/assertions/internal/oglematchers"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+)
+
+func TestPassingTest(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// PassingTest
+////////////////////////////////////////////////////////////////////////
+
+type PassingTest struct {
+}
+
+func init() { RegisterTestSuite(&PassingTest{}) }
+
+func (t *PassingTest) EmptyTestMethod() {
+}
+
+func (t *PassingTest) SuccessfullMatches() {
+	ExpectThat(17, Equals(17.0))
+	ExpectThat(16.9, LessThan(17))
+	ExpectThat("taco", HasSubstr("ac"))
+
+	AssertThat(17, Equals(17.0))
+	AssertThat(16.9, LessThan(17))
+	AssertThat("taco", HasSubstr("ac"))
+}
+
+func (t *PassingTest) ExpectAliases() {
+	ExpectEq(17, 17.0)
+
+	ExpectLe(17, 17.0)
+	ExpectLe(17, 18.0)
+	ExpectLt(17, 18.0)
+
+	ExpectGe(17, 17.0)
+	ExpectGe(17, 16.0)
+	ExpectGt(17, 16.0)
+
+	ExpectNe(17, 18.0)
+
+	ExpectTrue(true)
+	ExpectFalse(false)
+}
+
+func (t *PassingTest) AssertAliases() {
+	AssertEq(17, 17.0)
+
+	AssertLe(17, 17.0)
+	AssertLe(17, 18.0)
+	AssertLt(17, 18.0)
+
+	AssertGe(17, 17.0)
+	AssertGe(17, 16.0)
+	AssertGt(17, 16.0)
+
+	AssertNe(17, 18.0)
+
+	AssertTrue(true)
+	AssertFalse(false)
+}
+
+func (t *PassingTest) SlowTest() {
+	time.Sleep(37 * time.Millisecond)
+}
+
+////////////////////////////////////////////////////////////////////////
+// PassingTestWithHelpers
+////////////////////////////////////////////////////////////////////////
+
+type PassingTestWithHelpers struct {
+}
+
+var _ SetUpTestSuiteInterface = &PassingTestWithHelpers{}
+var _ SetUpInterface = &PassingTestWithHelpers{}
+var _ TearDownInterface = &PassingTestWithHelpers{}
+var _ TearDownTestSuiteInterface = &PassingTestWithHelpers{}
+
+func init() { RegisterTestSuite(&PassingTestWithHelpers{}) }
+
+func (t *PassingTestWithHelpers) SetUpTestSuite() {
+	fmt.Println("SetUpTestSuite ran.")
+}
+
+func (t *PassingTestWithHelpers) SetUp(ti *TestInfo) {
+	fmt.Println("SetUp ran.")
+}
+
+func (t *PassingTestWithHelpers) TearDown() {
+	fmt.Println("TearDown ran.")
+}
+
+func (t *PassingTestWithHelpers) TearDownTestSuite() {
+	fmt.Println("TearDownTestSuite ran.")
+}
+
+func (t *PassingTestWithHelpers) EmptyTestMethod() {
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/run_twice.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/run_twice.test.go
@@ -1,0 +1,47 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	. "github.com/smartystreets/assertions/internal/oglematchers"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+	"testing"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+type RunTwiceTest struct {
+}
+
+func init() { RegisterTestSuite(&RunTwiceTest{}) }
+
+// Set up two helpers that call RunTests. The test should still only be run
+// once.
+func TestOgletest(t *testing.T)  { RunTests(t) }
+func TestOgletest2(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *RunTwiceTest) PassingMethod() {
+}
+
+func (t *RunTwiceTest) FailingMethod() {
+	ExpectThat(17, Equals(17.5))
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/stop.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/stop.test.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/assertions/internal/ogletest"
+)
+
+func TestStop(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type StopTest struct {
+}
+
+var _ TearDownInterface = &StopTest{}
+var _ TearDownTestSuiteInterface = &StopTest{}
+
+func init() { RegisterTestSuite(&StopTest{}) }
+
+func (t *StopTest) TearDown() {
+	fmt.Println("TearDown running.")
+}
+
+func (t *StopTest) TearDownTestSuite() {
+	fmt.Println("TearDownTestSuite running.")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *StopTest) First() {
+}
+
+func (t *StopTest) Second() {
+	fmt.Println("About to call StopRunningTests.")
+	StopRunningTests()
+	fmt.Println("Called StopRunningTests.")
+}
+
+func (t *StopTest) Third() {
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/unexported.test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_cases/unexported.test.go
@@ -1,0 +1,43 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers_test
+
+import (
+	. "github.com/smartystreets/assertions/internal/oglematchers"
+	. "github.com/smartystreets/assertions/internal/ogletest"
+	"testing"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+type UnexportedTest struct {
+}
+
+func init()                           { RegisterTestSuite(&UnexportedTest{}) }
+func TestUnexportedTest(t *testing.T) { RunTests(t) }
+
+func (t *UnexportedTest) someUnexportedMethod() {
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *UnexportedTest) SomeTest() {
+	ExpectThat(3, Equals(4))
+}

--- a/vendor/github.com/smartystreets/assertions/internal/ogletest/test_info.go
+++ b/vendor/github.com/smartystreets/assertions/internal/ogletest/test_info.go
@@ -1,0 +1,91 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ogletest
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+
+	"github.com/smartystreets/assertions/internal/oglemock"
+)
+
+// TestInfo represents information about a currently running or previously-run
+// test.
+type TestInfo struct {
+	// A mock controller that is set up to report errors to the ogletest test
+	// runner. This can be used for setting up mock expectations and handling
+	// mock calls. The Finish method should not be run by the user; ogletest will
+	// do that automatically after the test's TearDown method is run.
+	//
+	// Note that this feature is still experimental, and is subject to change.
+	MockController oglemock.Controller
+
+	// A context that can be used by tests for long-running operations. In
+	// particular, this enables conveniently tracing the execution of a test
+	// function with reqtrace.
+	Ctx context.Context
+
+	// A mutex protecting shared state.
+	mu sync.RWMutex
+
+	// A set of failure records that the test has produced.
+	//
+	// GUARDED_BY(mu)
+	failureRecords []FailureRecord
+}
+
+// currentlyRunningTest is the state for the currently running test, if any.
+var currentlyRunningTest *TestInfo
+
+// newTestInfo creates a valid but empty TestInfo struct.
+func newTestInfo() (info *TestInfo) {
+	info = &TestInfo{}
+	info.MockController = oglemock.NewController(&testInfoErrorReporter{info})
+	info.Ctx = context.Background()
+
+	return
+}
+
+// testInfoErrorReporter is an oglemock.ErrorReporter that writes failure
+// records into a test info struct.
+type testInfoErrorReporter struct {
+	testInfo *TestInfo
+}
+
+func (r *testInfoErrorReporter) ReportError(
+	fileName string,
+	lineNumber int,
+	err error) {
+	r.testInfo.mu.Lock()
+	defer r.testInfo.mu.Unlock()
+
+	record := FailureRecord{
+		FileName:   fileName,
+		LineNumber: lineNumber,
+		Error:      err.Error(),
+	}
+
+	r.testInfo.failureRecords = append(r.testInfo.failureRecords, record)
+}
+
+func (r *testInfoErrorReporter) ReportFatalError(
+	fileName string,
+	lineNumber int,
+	err error) {
+	r.ReportError(fileName, lineNumber, err)
+	AbortTest()
+}

--- a/vendor/github.com/smartystreets/assertions/internal/reqtrace/reqtrace.go
+++ b/vendor/github.com/smartystreets/assertions/internal/reqtrace/reqtrace.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package reqtrace contains a very simple request tracing framework.
+package reqtrace
+
+import (
+	"flag"
+
+	"golang.org/x/net/context"
+)
+
+type contextKey int
+
+var fEnabled = flag.Bool("reqtrace.enable", false, "Collect and print traces.")
+
+// The key used to associate a *traceState with a context.
+const traceStateKey contextKey = 0
+
+// A function that must be called exactly once to report the outcome of an
+// operation represented by a span.
+type ReportFunc func(error)
+
+// Return false only if traces are disabled, i.e. Trace will never cause a
+// trace to be initiated.
+//
+// REQUIRES: flag.Parsed()
+func Enabled() (enabled bool) {
+	enabled = *fEnabled
+	return
+}
+
+// Begin a span within the current trace. Return a new context that should be
+// used for operations that logically occur within the span, and a report
+// function that must be called with the outcome of the logical operation
+// represented by the span.
+//
+// If no trace is active, no span will be created but ctx and report will still
+// be valid.
+func StartSpan(
+	parent context.Context,
+	desc string) (ctx context.Context, report ReportFunc) {
+	// Look for the trace state.
+	val := parent.Value(traceStateKey)
+	if val == nil {
+		// Nothing to do.
+		ctx = parent
+		report = func(err error) {}
+		return
+	}
+
+	ts := val.(*traceState)
+
+	// Set up the report function.
+	report = ts.CreateSpan(desc)
+
+	// For now we don't do anything interesting with the context. In the future,
+	// we may use it to record span hierarchy.
+	ctx = parent
+
+	return
+}
+
+// A wrapper around StartSpan that can be more convenient to use when the
+// lifetime of a span matches the lifetime of a function. Intended to be used
+// in a defer statement within a function using a named error return parameter.
+//
+// Equivalent to calling StartSpan with *ctx, replacing *ctx with the resulting
+// new context, then setting f to a function that will invoke the report
+// function with the contents of *error at the time that it is called.
+//
+// Example:
+//
+//     func DoSomething(ctx context.Context) (err error) {
+//       defer reqtrace.StartSpanWithError(&ctx, &err, "DoSomething")()
+//       [...]
+//     }
+//
+func StartSpanWithError(
+	ctx *context.Context,
+	err *error,
+	desc string) (f func()) {
+	var report ReportFunc
+	*ctx, report = StartSpan(*ctx, desc)
+	f = func() { report(*err) }
+	return
+}
+
+// Like StartSpan, but begins a root span for a new trace if no trace is active
+// in the supplied context and tracing is enabled for the process.
+func Trace(
+	parent context.Context,
+	desc string) (ctx context.Context, report ReportFunc) {
+	// If tracing is disabled, this is a no-op.
+	if !*fEnabled {
+		ctx = parent
+		report = func(err error) {}
+		return
+	}
+
+	// Is this context already being traced? If so, simply add a span.
+	if parent.Value(traceStateKey) != nil {
+		ctx, report = StartSpan(parent, desc)
+		return
+	}
+
+	// Set up a new trace state.
+	ts := new(traceState)
+	baseReport := ts.CreateSpan(desc)
+
+	// Log when finished.
+	report = func(err error) {
+		baseReport(err)
+		ts.Log()
+	}
+
+	// Set up the context.
+	ctx = context.WithValue(parent, traceStateKey, ts)
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/reqtrace/trace_state.go
+++ b/vendor/github.com/smartystreets/assertions/internal/reqtrace/trace_state.go
@@ -1,0 +1,175 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reqtrace
+
+import (
+	"log"
+	"math"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const logFlags = 0
+
+var gLogger = log.New(os.Stderr, "reqtrace: ", logFlags)
+
+type span struct {
+	// Fixed at creation.
+	desc  string
+	start time.Time
+
+	// Updated by report functions.
+	finished bool
+	end      time.Time
+	err      error
+}
+
+// All of the state for a particular trace root. The zero value is usable.
+type traceState struct {
+	mu sync.Mutex
+
+	// The list of spans associated with this state. Append-only.
+	//
+	// GUARDED_BY(mu)
+	spans []*span
+}
+
+func (ts *traceState) report(spanIndex int, err error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	s := ts.spans[spanIndex]
+	s.finished = true
+	s.end = time.Now()
+	s.err = err
+}
+
+// Associate a new span with the trace. Return a function that will report its
+// completion.
+func (ts *traceState) CreateSpan(desc string) (report ReportFunc) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	index := len(ts.spans)
+	ts.spans = append(ts.spans, &span{desc: desc, start: time.Now()})
+
+	report = func(err error) { ts.report(index, err) }
+	return
+}
+
+func round(x float64) float64 {
+	if x < 0 {
+		return math.Ceil(x - 0.5)
+	}
+
+	return math.Floor(x + 0.5)
+}
+
+// Log information about the spans in this trace.
+func (ts *traceState) Log() {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	gLogger.Println()
+
+	// Special case: we require at least one span.
+	if len(ts.spans) == 0 {
+		return
+	}
+
+	// Print a banner for this trace.
+	const bannerHalfLength = 45
+
+	gLogger.Println()
+	gLogger.Printf(
+		"%s %s %s",
+		strings.Repeat("=", bannerHalfLength),
+		ts.spans[0].desc,
+		strings.Repeat("=", bannerHalfLength))
+	gLogger.Printf("Start time: %v", ts.spans[0].start.Format(time.RFC3339Nano))
+	gLogger.Println()
+
+	// Find the minimum start time and maximum end time of all durations.
+	var minStart time.Time
+	var maxEnd time.Time
+	for _, s := range ts.spans {
+		if !s.finished {
+			continue
+		}
+
+		if minStart.IsZero() || s.start.Before(minStart) {
+			minStart = s.start
+		}
+
+		if maxEnd.Before(s.end) {
+			maxEnd = s.end
+		}
+	}
+
+	// Bail out if something weird happened.
+	//
+	// TODO(jacobsa): Be more graceful.
+	totalDuration := maxEnd.Sub(minStart)
+	if minStart.IsZero() || maxEnd.IsZero() || totalDuration <= 0 {
+		gLogger.Println("(Weird trace)")
+		return
+	}
+
+	// Calculate the number of nanoseconds elapsed, as a floating point number.
+	totalNs := float64(totalDuration / time.Nanosecond)
+
+	// Log each span with some ASCII art showing its length relative to the
+	// total.
+	const totalNumCols float64 = 120
+	for _, s := range ts.spans {
+		if !s.finished {
+			gLogger.Printf("(Unfinished: %s)", s.desc)
+			gLogger.Println()
+			continue
+		}
+
+		// Calculate the duration of the span, and its width relative to the
+		// longest span.
+		d := s.end.Sub(s.start)
+		if d <= 0 {
+			gLogger.Println("(Weird duration)")
+			gLogger.Println()
+			continue
+		}
+
+		durationRatio := float64(d/time.Nanosecond) / totalNs
+
+		// We will offset the label and banner proportional to the time since the
+		// start of the earliest span.
+		offsetRatio := float64(s.start.Sub(minStart)/time.Nanosecond) / totalNs
+		offsetChars := int(round(offsetRatio * totalNumCols))
+		offsetStr := strings.Repeat(" ", offsetChars)
+
+		// Print the description and duration.
+		gLogger.Printf("%s%v", offsetStr, s.desc)
+		gLogger.Printf("%s%v", offsetStr, d)
+
+		// Print a banner showing the duration graphically.
+		bannerChars := int(round(durationRatio * totalNumCols))
+		var dashes string
+		if bannerChars > 2 {
+			dashes = strings.Repeat("-", bannerChars-2)
+		}
+
+		gLogger.Printf("%s|%s|", offsetStr, dashes)
+		gLogger.Println()
+	}
+}

--- a/vendor/github.com/smartystreets/assertions/messages.go
+++ b/vendor/github.com/smartystreets/assertions/messages.go
@@ -1,0 +1,93 @@
+package assertions
+
+const ( // equality
+	shouldHaveBeenEqual             = "Expected: '%v'\nActual:   '%v'\n(Should be equal)"
+	shouldNotHaveBeenEqual          = "Expected     '%v'\nto NOT equal '%v'\n(but it did)!"
+	shouldHaveBeenEqualTypeMismatch = "Expected: '%v' (%T)\nActual:   '%v' (%T)\n(Should be equal, type mismatch)"
+	shouldHaveBeenAlmostEqual       = "Expected '%v' to almost equal '%v' (but it didn't)!"
+	shouldHaveNotBeenAlmostEqual    = "Expected '%v' to NOT almost equal '%v' (but it did)!"
+	shouldHaveResembled             = "Expected: '%s'\nActual:   '%s'\n(Should resemble)!"
+	shouldNotHaveResembled          = "Expected        '%#v'\nto NOT resemble '%#v'\n(but it did)!"
+	shouldBePointers                = "Both arguments should be pointers "
+	shouldHaveBeenNonNilPointer     = shouldBePointers + "(the %s was %s)!"
+	shouldHavePointedTo             = "Expected '%+v' (address: '%v') and '%+v' (address: '%v') to be the same address (but their weren't)!"
+	shouldNotHavePointedTo          = "Expected '%+v' and '%+v' to be different references (but they matched: '%v')!"
+	shouldHaveBeenNil               = "Expected: nil\nActual:   '%v'"
+	shouldNotHaveBeenNil            = "Expected '%+v' to NOT be nil (but it was)!"
+	shouldHaveBeenTrue              = "Expected: true\nActual:   %v"
+	shouldHaveBeenFalse             = "Expected: false\nActual:   %v"
+	shouldHaveBeenZeroValue         = "'%+v' should have been the zero value" //"Expected: (zero value)\nActual:   %v"
+)
+
+const ( // quantity comparisons
+	shouldHaveBeenGreater            = "Expected '%v' to be greater than '%v' (but it wasn't)!"
+	shouldHaveBeenGreaterOrEqual     = "Expected '%v' to be greater than or equal to '%v' (but it wasn't)!"
+	shouldHaveBeenLess               = "Expected '%v' to be less than '%v' (but it wasn't)!"
+	shouldHaveBeenLessOrEqual        = "Expected '%v' to be less than or equal to '%v' (but it wasn't)!"
+	shouldHaveBeenBetween            = "Expected '%v' to be between '%v' and '%v' (but it wasn't)!"
+	shouldNotHaveBeenBetween         = "Expected '%v' NOT to be between '%v' and '%v' (but it was)!"
+	shouldHaveDifferentUpperAndLower = "The lower and upper bounds must be different values (they were both '%v')."
+	shouldHaveBeenBetweenOrEqual     = "Expected '%v' to be between '%v' and '%v' or equal to one of them (but it wasn't)!"
+	shouldNotHaveBeenBetweenOrEqual  = "Expected '%v' NOT to be between '%v' and '%v' or equal to one of them (but it was)!"
+)
+
+const ( // collections
+	shouldHaveContained            = "Expected the container (%v) to contain: '%v' (but it didn't)!"
+	shouldNotHaveContained         = "Expected the container (%v) NOT to contain: '%v' (but it did)!"
+	shouldHaveContainedKey         = "Expected the %v to contain the key: %v (but it didn't)!"
+	shouldNotHaveContainedKey      = "Expected the %v NOT to contain the key: %v (but it did)!"
+	shouldHaveBeenIn               = "Expected '%v' to be in the container (%v), but it wasn't!"
+	shouldNotHaveBeenIn            = "Expected '%v' NOT to be in the container (%v), but it was!"
+	shouldHaveBeenAValidCollection = "You must provide a valid container (was %v)!"
+	shouldHaveBeenAValidMap        = "You must provide a valid map type (was %v)!"
+	shouldHaveBeenEmpty            = "Expected %+v to be empty (but it wasn't)!"
+	shouldNotHaveBeenEmpty         = "Expected %+v to NOT be empty (but it was)!"
+	shouldHaveBeenAValidInteger    = "You must provide a valid integer (was %v)!"
+	shouldHaveBeenAValidLength     = "You must provide a valid positive integer (was %v)!"
+	shouldHaveHadLength            = "Expected %+v (length: %v) to have length equal to '%v', but it wasn't!"
+)
+
+const ( // strings
+	shouldHaveStartedWith           = "Expected      '%v'\nto start with '%v'\n(but it didn't)!"
+	shouldNotHaveStartedWith        = "Expected          '%v'\nNOT to start with '%v'\n(but it did)!"
+	shouldHaveEndedWith             = "Expected    '%v'\nto end with '%v'\n(but it didn't)!"
+	shouldNotHaveEndedWith          = "Expected        '%v'\nNOT to end with '%v'\n(but it did)!"
+	shouldAllBeStrings              = "All arguments to this assertion must be strings (you provided: %v)."
+	shouldBothBeStrings             = "Both arguments to this assertion must be strings (you provided %v and %v)."
+	shouldBeString                  = "The argument to this assertion must be a string (you provided %v)."
+	shouldHaveContainedSubstring    = "Expected '%s' to contain substring '%s' (but it didn't)!"
+	shouldNotHaveContainedSubstring = "Expected '%s' NOT to contain substring '%s' (but it did)!"
+	shouldHaveBeenBlank             = "Expected '%s' to be blank (but it wasn't)!"
+	shouldNotHaveBeenBlank          = "Expected value to NOT be blank (but it was)!"
+)
+
+const ( // panics
+	shouldUseVoidNiladicFunction = "You must provide a void, niladic function as the first argument!"
+	shouldHavePanickedWith       = "Expected func() to panic with '%v' (but it panicked with '%v')!"
+	shouldHavePanicked           = "Expected func() to panic (but it didn't)!"
+	shouldNotHavePanicked        = "Expected func() NOT to panic (error: '%+v')!"
+	shouldNotHavePanickedWith    = "Expected func() NOT to panic with '%v' (but it did)!"
+)
+
+const ( // type checking
+	shouldHaveBeenA    = "Expected '%v' to be: '%v' (but was: '%v')!"
+	shouldNotHaveBeenA = "Expected '%v' to NOT be: '%v' (but it was)!"
+
+	shouldHaveImplemented             = "Expected: '%v interface support'\nActual:   '%v' does not implement the interface!"
+	shouldNotHaveImplemented          = "Expected         '%v'\nto NOT implement '%v'\n(but it did)!"
+	shouldCompareWithInterfacePointer = "The expected value must be a pointer to an interface type (eg. *fmt.Stringer)"
+	shouldNotBeNilActual              = "The actual value was 'nil' and should be a value or a pointer to a value!"
+)
+
+const ( // time comparisons
+	shouldUseTimes                   = "You must provide time instances as arguments to this assertion."
+	shouldUseTimeSlice               = "You must provide a slice of time instances as the first argument to this assertion."
+	shouldUseDurationAndTime         = "You must provide a duration and a time as arguments to this assertion."
+	shouldHaveHappenedBefore         = "Expected '%v' to happen before '%v' (it happened '%v' after)!"
+	shouldHaveHappenedAfter          = "Expected '%v' to happen after '%v' (it happened '%v' before)!"
+	shouldHaveHappenedBetween        = "Expected '%v' to happen between '%v' and '%v' (it happened '%v' outside threshold)!"
+	shouldNotHaveHappenedOnOrBetween = "Expected '%v' to NOT happen on or between '%v' and '%v' (but it did)!"
+
+	// format params: incorrect-index, previous-index, previous-time, incorrect-index, incorrect-time
+	shouldHaveBeenChronological = "The 'Time' at index [%d] should have happened after the previous one (but it didn't!):\n  [%d]: %s\n  [%d]: %s (see, it happened before!)"
+)

--- a/vendor/github.com/smartystreets/assertions/panic.go
+++ b/vendor/github.com/smartystreets/assertions/panic.go
@@ -1,0 +1,115 @@
+package assertions
+
+import "fmt"
+
+// ShouldPanic receives a void, niladic function and expects to recover a panic.
+func ShouldPanic(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			message = shouldHavePanicked
+		} else {
+			message = success
+		}
+	}()
+	action()
+
+	return
+}
+
+// ShouldNotPanic receives a void, niladic function and expects to execute the function without any panic.
+func ShouldNotPanic(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered != nil {
+			message = fmt.Sprintf(shouldNotHavePanicked, recovered)
+		} else {
+			message = success
+		}
+	}()
+	action()
+
+	return
+}
+
+// ShouldPanicWith receives a void, niladic function and expects to recover a panic with the second argument as the content.
+func ShouldPanicWith(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			message = shouldHavePanicked
+		} else {
+			if equal := ShouldEqual(recovered, expected[0]); equal != success {
+				message = serializer.serialize(expected[0], recovered, fmt.Sprintf(shouldHavePanickedWith, expected[0], recovered))
+			} else {
+				message = success
+			}
+		}
+	}()
+	action()
+
+	return
+}
+
+// ShouldNotPanicWith receives a void, niladic function and expects to recover a panic whose content differs from the second argument.
+func ShouldNotPanicWith(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			message = success
+		} else {
+			if equal := ShouldEqual(recovered, expected[0]); equal == success {
+				message = fmt.Sprintf(shouldNotHavePanickedWith, expected[0])
+			} else {
+				message = success
+			}
+		}
+	}()
+	action()
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/quantity.go
+++ b/vendor/github.com/smartystreets/assertions/quantity.go
@@ -1,0 +1,141 @@
+package assertions
+
+import (
+	"fmt"
+
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+// ShouldBeGreaterThan receives exactly two parameters and ensures that the first is greater than the second.
+func ShouldBeGreaterThan(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	if matchError := oglematchers.GreaterThan(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenGreater, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeGreaterThanOrEqualTo receives exactly two parameters and ensures that the first is greater than or equal to the second.
+func ShouldBeGreaterThanOrEqualTo(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if matchError := oglematchers.GreaterOrEqual(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenGreaterOrEqual, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeLessThan receives exactly two parameters and ensures that the first is less than the second.
+func ShouldBeLessThan(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if matchError := oglematchers.LessThan(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenLess, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeLessThan receives exactly two parameters and ensures that the first is less than or equal to the second.
+func ShouldBeLessThanOrEqualTo(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if matchError := oglematchers.LessOrEqual(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenLessOrEqual, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeBetween receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is between both bounds (but not equal to either of them).
+func ShouldBeBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if !isBetween(actual, lower, upper) {
+		return fmt.Sprintf(shouldHaveBeenBetween, actual, lower, upper)
+	}
+	return success
+}
+
+// ShouldNotBeBetween receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is NOT between both bounds.
+func ShouldNotBeBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if isBetween(actual, lower, upper) {
+		return fmt.Sprintf(shouldNotHaveBeenBetween, actual, lower, upper)
+	}
+	return success
+}
+func deriveBounds(values []interface{}) (lower interface{}, upper interface{}, fail string) {
+	lower = values[0]
+	upper = values[1]
+
+	if ShouldNotEqual(lower, upper) != success {
+		return nil, nil, fmt.Sprintf(shouldHaveDifferentUpperAndLower, lower)
+	} else if ShouldBeLessThan(lower, upper) != success {
+		lower, upper = upper, lower
+	}
+	return lower, upper, success
+}
+func isBetween(value, lower, upper interface{}) bool {
+	if ShouldBeGreaterThan(value, lower) != success {
+		return false
+	} else if ShouldBeLessThan(value, upper) != success {
+		return false
+	}
+	return true
+}
+
+// ShouldBeBetweenOrEqual receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is between both bounds or equal to one of them.
+func ShouldBeBetweenOrEqual(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if !isBetweenOrEqual(actual, lower, upper) {
+		return fmt.Sprintf(shouldHaveBeenBetweenOrEqual, actual, lower, upper)
+	}
+	return success
+}
+
+// ShouldNotBeBetweenOrEqual receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is nopt between the bounds nor equal to either of them.
+func ShouldNotBeBetweenOrEqual(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if isBetweenOrEqual(actual, lower, upper) {
+		return fmt.Sprintf(shouldNotHaveBeenBetweenOrEqual, actual, lower, upper)
+	}
+	return success
+}
+
+func isBetweenOrEqual(value, lower, upper interface{}) bool {
+	if ShouldBeGreaterThanOrEqualTo(value, lower) != success {
+		return false
+	} else if ShouldBeLessThanOrEqualTo(value, upper) != success {
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/smartystreets/assertions/serializer.go
+++ b/vendor/github.com/smartystreets/assertions/serializer.go
@@ -1,0 +1,69 @@
+package assertions
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/smartystreets/assertions/internal/go-render/render"
+)
+
+type Serializer interface {
+	serialize(expected, actual interface{}, message string) string
+	serializeDetailed(expected, actual interface{}, message string) string
+}
+
+type failureSerializer struct{}
+
+func (self *failureSerializer) serializeDetailed(expected, actual interface{}, message string) string {
+	view := FailureView{
+		Message:  message,
+		Expected: render.Render(expected),
+		Actual:   render.Render(actual),
+	}
+	serialized, err := json.Marshal(view)
+	if err != nil {
+		return message
+	}
+	return string(serialized)
+}
+
+func (self *failureSerializer) serialize(expected, actual interface{}, message string) string {
+	view := FailureView{
+		Message:  message,
+		Expected: fmt.Sprintf("%+v", expected),
+		Actual:   fmt.Sprintf("%+v", actual),
+	}
+	serialized, err := json.Marshal(view)
+	if err != nil {
+		return message
+	}
+	return string(serialized)
+}
+
+func newSerializer() *failureSerializer {
+	return &failureSerializer{}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// This struct is also declared in github.com/smartystreets/goconvey/convey/reporting.
+// The json struct tags should be equal in both declarations.
+type FailureView struct {
+	Message  string `json:"Message"`
+	Expected string `json:"Expected"`
+	Actual   string `json:"Actual"`
+}
+
+///////////////////////////////////////////////////////
+
+// noopSerializer just gives back the original message. This is useful when we are using
+// the assertions from a context other than the web UI, that requires the JSON structure
+// provided by the failureSerializer.
+type noopSerializer struct{}
+
+func (self *noopSerializer) serialize(expected, actual interface{}, message string) string {
+	return message
+}
+func (self *noopSerializer) serializeDetailed(expected, actual interface{}, message string) string {
+	return message
+}

--- a/vendor/github.com/smartystreets/assertions/should/should.go
+++ b/vendor/github.com/smartystreets/assertions/should/should.go
@@ -1,0 +1,73 @@
+// package should is simply a rewording of the assertion
+// functions in the assertions package.
+package should
+
+import "github.com/smartystreets/assertions"
+
+var (
+	Equal          = assertions.ShouldEqual
+	NotEqual       = assertions.ShouldNotEqual
+	AlmostEqual    = assertions.ShouldAlmostEqual
+	NotAlmostEqual = assertions.ShouldNotAlmostEqual
+	Resemble       = assertions.ShouldResemble
+	NotResemble    = assertions.ShouldNotResemble
+	PointTo        = assertions.ShouldPointTo
+	NotPointTo     = assertions.ShouldNotPointTo
+	BeNil          = assertions.ShouldBeNil
+	NotBeNil       = assertions.ShouldNotBeNil
+	BeTrue         = assertions.ShouldBeTrue
+	BeFalse        = assertions.ShouldBeFalse
+	BeZeroValue    = assertions.ShouldBeZeroValue
+
+	BeGreaterThan          = assertions.ShouldBeGreaterThan
+	BeGreaterThanOrEqualTo = assertions.ShouldBeGreaterThanOrEqualTo
+	BeLessThan             = assertions.ShouldBeLessThan
+	BeLessThanOrEqualTo    = assertions.ShouldBeLessThanOrEqualTo
+	BeBetween              = assertions.ShouldBeBetween
+	NotBeBetween           = assertions.ShouldNotBeBetween
+	BeBetweenOrEqual       = assertions.ShouldBeBetweenOrEqual
+	NotBeBetweenOrEqual    = assertions.ShouldNotBeBetweenOrEqual
+
+	Contain       = assertions.ShouldContain
+	NotContain    = assertions.ShouldNotContain
+	ContainKey    = assertions.ShouldContainKey
+	NotContainKey = assertions.ShouldNotContainKey
+	BeIn          = assertions.ShouldBeIn
+	NotBeIn       = assertions.ShouldNotBeIn
+	BeEmpty       = assertions.ShouldBeEmpty
+	NotBeEmpty    = assertions.ShouldNotBeEmpty
+	HaveLength    = assertions.ShouldHaveLength
+
+	StartWith           = assertions.ShouldStartWith
+	NotStartWith        = assertions.ShouldNotStartWith
+	EndWith             = assertions.ShouldEndWith
+	NotEndWith          = assertions.ShouldNotEndWith
+	BeBlank             = assertions.ShouldBeBlank
+	NotBeBlank          = assertions.ShouldNotBeBlank
+	ContainSubstring    = assertions.ShouldContainSubstring
+	NotContainSubstring = assertions.ShouldNotContainSubstring
+
+	EqualWithout   = assertions.ShouldEqualWithout
+	EqualTrimSpace = assertions.ShouldEqualTrimSpace
+
+	Panic        = assertions.ShouldPanic
+	NotPanic     = assertions.ShouldNotPanic
+	PanicWith    = assertions.ShouldPanicWith
+	NotPanicWith = assertions.ShouldNotPanicWith
+
+	HaveSameTypeAs    = assertions.ShouldHaveSameTypeAs
+	NotHaveSameTypeAs = assertions.ShouldNotHaveSameTypeAs
+	Implement         = assertions.ShouldImplement
+	NotImplement      = assertions.ShouldNotImplement
+
+	HappenBefore         = assertions.ShouldHappenBefore
+	HappenOnOrBefore     = assertions.ShouldHappenOnOrBefore
+	HappenAfter          = assertions.ShouldHappenAfter
+	HappenOnOrAfter      = assertions.ShouldHappenOnOrAfter
+	HappenBetween        = assertions.ShouldHappenBetween
+	HappenOnOrBetween    = assertions.ShouldHappenOnOrBetween
+	NotHappenOnOrBetween = assertions.ShouldNotHappenOnOrBetween
+	HappenWithin         = assertions.ShouldHappenWithin
+	NotHappenWithin      = assertions.ShouldNotHappenWithin
+	BeChronological      = assertions.ShouldBeChronological
+)

--- a/vendor/github.com/smartystreets/assertions/strings.go
+++ b/vendor/github.com/smartystreets/assertions/strings.go
@@ -1,0 +1,227 @@
+package assertions
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// ShouldStartWith receives exactly 2 string parameters and ensures that the first starts with the second.
+func ShouldStartWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	prefix, prefixIsString := expected[0].(string)
+
+	if !valueIsString || !prefixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldStartWith(value, prefix)
+}
+func shouldStartWith(value, prefix string) string {
+	if !strings.HasPrefix(value, prefix) {
+		shortval := value
+		if len(shortval) > len(prefix) {
+			shortval = shortval[:len(prefix)] + "..."
+		}
+		return serializer.serialize(prefix, shortval, fmt.Sprintf(shouldHaveStartedWith, value, prefix))
+	}
+	return success
+}
+
+// ShouldNotStartWith receives exactly 2 string parameters and ensures that the first does not start with the second.
+func ShouldNotStartWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	prefix, prefixIsString := expected[0].(string)
+
+	if !valueIsString || !prefixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldNotStartWith(value, prefix)
+}
+func shouldNotStartWith(value, prefix string) string {
+	if strings.HasPrefix(value, prefix) {
+		if value == "" {
+			value = "<empty>"
+		}
+		if prefix == "" {
+			prefix = "<empty>"
+		}
+		return fmt.Sprintf(shouldNotHaveStartedWith, value, prefix)
+	}
+	return success
+}
+
+// ShouldEndWith receives exactly 2 string parameters and ensures that the first ends with the second.
+func ShouldEndWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	suffix, suffixIsString := expected[0].(string)
+
+	if !valueIsString || !suffixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldEndWith(value, suffix)
+}
+func shouldEndWith(value, suffix string) string {
+	if !strings.HasSuffix(value, suffix) {
+		shortval := value
+		if len(shortval) > len(suffix) {
+			shortval = "..." + shortval[len(shortval)-len(suffix):]
+		}
+		return serializer.serialize(suffix, shortval, fmt.Sprintf(shouldHaveEndedWith, value, suffix))
+	}
+	return success
+}
+
+// ShouldEndWith receives exactly 2 string parameters and ensures that the first does not end with the second.
+func ShouldNotEndWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	suffix, suffixIsString := expected[0].(string)
+
+	if !valueIsString || !suffixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldNotEndWith(value, suffix)
+}
+func shouldNotEndWith(value, suffix string) string {
+	if strings.HasSuffix(value, suffix) {
+		if value == "" {
+			value = "<empty>"
+		}
+		if suffix == "" {
+			suffix = "<empty>"
+		}
+		return fmt.Sprintf(shouldNotHaveEndedWith, value, suffix)
+	}
+	return success
+}
+
+// ShouldContainSubstring receives exactly 2 string parameters and ensures that the first contains the second as a substring.
+func ShouldContainSubstring(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	long, longOk := actual.(string)
+	short, shortOk := expected[0].(string)
+
+	if !longOk || !shortOk {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	if !strings.Contains(long, short) {
+		return serializer.serialize(expected[0], actual, fmt.Sprintf(shouldHaveContainedSubstring, long, short))
+	}
+	return success
+}
+
+// ShouldNotContainSubstring receives exactly 2 string parameters and ensures that the first does NOT contain the second as a substring.
+func ShouldNotContainSubstring(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	long, longOk := actual.(string)
+	short, shortOk := expected[0].(string)
+
+	if !longOk || !shortOk {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	if strings.Contains(long, short) {
+		return fmt.Sprintf(shouldNotHaveContainedSubstring, long, short)
+	}
+	return success
+}
+
+// ShouldBeBlank receives exactly 1 string parameter and ensures that it is equal to "".
+func ShouldBeBlank(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+	value, ok := actual.(string)
+	if !ok {
+		return fmt.Sprintf(shouldBeString, reflect.TypeOf(actual))
+	}
+	if value != "" {
+		return serializer.serialize("", value, fmt.Sprintf(shouldHaveBeenBlank, value))
+	}
+	return success
+}
+
+// ShouldNotBeBlank receives exactly 1 string parameter and ensures that it is equal to "".
+func ShouldNotBeBlank(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+	value, ok := actual.(string)
+	if !ok {
+		return fmt.Sprintf(shouldBeString, reflect.TypeOf(actual))
+	}
+	if value == "" {
+		return shouldNotHaveBeenBlank
+	}
+	return success
+}
+
+// ShouldEqualWithout receives exactly 3 string parameters and ensures that the first is equal to the second
+// after removing all instances of the third from the first using strings.Replace(first, third, "", -1).
+func ShouldEqualWithout(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualString, ok1 := actual.(string)
+	expectedString, ok2 := expected[0].(string)
+	replace, ok3 := expected[1].(string)
+
+	if !ok1 || !ok2 || !ok3 {
+		return fmt.Sprintf(shouldAllBeStrings, []reflect.Type{
+			reflect.TypeOf(actual),
+			reflect.TypeOf(expected[0]),
+			reflect.TypeOf(expected[1]),
+		})
+	}
+
+	replaced := strings.Replace(actualString, replace, "", -1)
+	if replaced == expectedString {
+		return ""
+	}
+
+	return fmt.Sprintf("Expected '%s' to equal '%s' but without any '%s' (but it didn't).", actualString, expectedString, replace)
+}
+
+// ShouldEqualTrimSpace receives exactly 2 string parameters and ensures that the first is equal to the second
+// after removing all leading and trailing whitespace using strings.TrimSpace(first).
+func ShouldEqualTrimSpace(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	actualString, valueIsString := actual.(string)
+	_, value2IsString := expected[0].(string)
+
+	if !valueIsString || !value2IsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	actualString = strings.TrimSpace(actualString)
+	return ShouldEqual(actualString, expected[0])
+}

--- a/vendor/github.com/smartystreets/assertions/time.go
+++ b/vendor/github.com/smartystreets/assertions/time.go
@@ -1,0 +1,202 @@
+package assertions
+
+import (
+	"fmt"
+	"time"
+)
+
+// ShouldHappenBefore receives exactly 2 time.Time arguments and asserts that the first happens before the second.
+func ShouldHappenBefore(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+
+	if !actualTime.Before(expectedTime) {
+		return fmt.Sprintf(shouldHaveHappenedBefore, actualTime, expectedTime, actualTime.Sub(expectedTime))
+	}
+
+	return success
+}
+
+// ShouldHappenOnOrBefore receives exactly 2 time.Time arguments and asserts that the first happens on or before the second.
+func ShouldHappenOnOrBefore(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+
+	if actualTime.Equal(expectedTime) {
+		return success
+	}
+	return ShouldHappenBefore(actualTime, expectedTime)
+}
+
+// ShouldHappenAfter receives exactly 2 time.Time arguments and asserts that the first happens after the second.
+func ShouldHappenAfter(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+	if !actualTime.After(expectedTime) {
+		return fmt.Sprintf(shouldHaveHappenedAfter, actualTime, expectedTime, expectedTime.Sub(actualTime))
+	}
+	return success
+}
+
+// ShouldHappenOnOrAfter receives exactly 2 time.Time arguments and asserts that the first happens on or after the second.
+func ShouldHappenOnOrAfter(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+	if actualTime.Equal(expectedTime) {
+		return success
+	}
+	return ShouldHappenAfter(actualTime, expectedTime)
+}
+
+// ShouldHappenBetween receives exactly 3 time.Time arguments and asserts that the first happens between (not on) the second and third.
+func ShouldHappenBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	min, secondOk := expected[0].(time.Time)
+	max, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseTimes
+	}
+
+	if !actualTime.After(min) {
+		return fmt.Sprintf(shouldHaveHappenedBetween, actualTime, min, max, min.Sub(actualTime))
+	}
+	if !actualTime.Before(max) {
+		return fmt.Sprintf(shouldHaveHappenedBetween, actualTime, min, max, actualTime.Sub(max))
+	}
+	return success
+}
+
+// ShouldHappenOnOrBetween receives exactly 3 time.Time arguments and asserts that the first happens between or on the second and third.
+func ShouldHappenOnOrBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	min, secondOk := expected[0].(time.Time)
+	max, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseTimes
+	}
+	if actualTime.Equal(min) || actualTime.Equal(max) {
+		return success
+	}
+	return ShouldHappenBetween(actualTime, min, max)
+}
+
+// ShouldNotHappenOnOrBetween receives exactly 3 time.Time arguments and asserts that the first
+// does NOT happen between or on the second or third.
+func ShouldNotHappenOnOrBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	min, secondOk := expected[0].(time.Time)
+	max, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseTimes
+	}
+	if actualTime.Equal(min) || actualTime.Equal(max) {
+		return fmt.Sprintf(shouldNotHaveHappenedOnOrBetween, actualTime, min, max)
+	}
+	if actualTime.After(min) && actualTime.Before(max) {
+		return fmt.Sprintf(shouldNotHaveHappenedOnOrBetween, actualTime, min, max)
+	}
+	return success
+}
+
+// ShouldHappenWithin receives a time.Time, a time.Duration, and a time.Time (3 arguments)
+// and asserts that the first time.Time happens within or on the duration specified relative to
+// the other time.Time.
+func ShouldHappenWithin(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	tolerance, secondOk := expected[0].(time.Duration)
+	threshold, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseDurationAndTime
+	}
+
+	min := threshold.Add(-tolerance)
+	max := threshold.Add(tolerance)
+	return ShouldHappenOnOrBetween(actualTime, min, max)
+}
+
+// ShouldNotHappenWithin receives a time.Time, a time.Duration, and a time.Time (3 arguments)
+// and asserts that the first time.Time does NOT happen within or on the duration specified relative to
+// the other time.Time.
+func ShouldNotHappenWithin(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	tolerance, secondOk := expected[0].(time.Duration)
+	threshold, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseDurationAndTime
+	}
+
+	min := threshold.Add(-tolerance)
+	max := threshold.Add(tolerance)
+	return ShouldNotHappenOnOrBetween(actualTime, min, max)
+}
+
+// ShouldBeChronological receives a []time.Time slice and asserts that the are
+// in chronological order starting with the first time.Time as the earliest.
+func ShouldBeChronological(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	times, ok := actual.([]time.Time)
+	if !ok {
+		return shouldUseTimeSlice
+	}
+
+	var previous time.Time
+	for i, current := range times {
+		if i > 0 && current.Before(previous) {
+			return fmt.Sprintf(shouldHaveBeenChronological,
+				i, i-1, previous.String(), i, current.String())
+		}
+		previous = current
+	}
+	return ""
+}

--- a/vendor/github.com/smartystreets/assertions/type.go
+++ b/vendor/github.com/smartystreets/assertions/type.go
@@ -1,0 +1,112 @@
+package assertions
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ShouldHaveSameTypeAs receives exactly two parameters and compares their underlying types for equality.
+func ShouldHaveSameTypeAs(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	first := reflect.TypeOf(actual)
+	second := reflect.TypeOf(expected[0])
+
+	if equal := ShouldEqual(first, second); equal != success {
+		return serializer.serialize(second, first, fmt.Sprintf(shouldHaveBeenA, actual, second, first))
+	}
+	return success
+}
+
+// ShouldNotHaveSameTypeAs receives exactly two parameters and compares their underlying types for inequality.
+func ShouldNotHaveSameTypeAs(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	first := reflect.TypeOf(actual)
+	second := reflect.TypeOf(expected[0])
+
+	if equal := ShouldEqual(first, second); equal == success {
+		return fmt.Sprintf(shouldNotHaveBeenA, actual, second)
+	}
+	return success
+}
+
+// ShouldImplement receives exactly two parameters and ensures
+// that the first implements the interface type of the second.
+func ShouldImplement(actual interface{}, expectedList ...interface{}) string {
+	if fail := need(1, expectedList); fail != success {
+		return fail
+	}
+
+	expected := expectedList[0]
+	if fail := ShouldBeNil(expected); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	if fail := ShouldNotBeNil(actual); fail != success {
+		return shouldNotBeNilActual
+	}
+
+	var actualType reflect.Type
+	if reflect.TypeOf(actual).Kind() != reflect.Ptr {
+		actualType = reflect.PtrTo(reflect.TypeOf(actual))
+	} else {
+		actualType = reflect.TypeOf(actual)
+	}
+
+	expectedType := reflect.TypeOf(expected)
+	if fail := ShouldNotBeNil(expectedType); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	expectedInterface := expectedType.Elem()
+
+	if actualType == nil {
+		return fmt.Sprintf(shouldHaveImplemented, expectedInterface, actual)
+	}
+
+	if !actualType.Implements(expectedInterface) {
+		return fmt.Sprintf(shouldHaveImplemented, expectedInterface, actualType)
+	}
+	return success
+}
+
+// ShouldNotImplement receives exactly two parameters and ensures
+// that the first does NOT implement the interface type of the second.
+func ShouldNotImplement(actual interface{}, expectedList ...interface{}) string {
+	if fail := need(1, expectedList); fail != success {
+		return fail
+	}
+
+	expected := expectedList[0]
+	if fail := ShouldBeNil(expected); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	if fail := ShouldNotBeNil(actual); fail != success {
+		return shouldNotBeNilActual
+	}
+
+	var actualType reflect.Type
+	if reflect.TypeOf(actual).Kind() != reflect.Ptr {
+		actualType = reflect.PtrTo(reflect.TypeOf(actual))
+	} else {
+		actualType = reflect.TypeOf(actual)
+	}
+
+	expectedType := reflect.TypeOf(expected)
+	if fail := ShouldNotBeNil(expectedType); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	expectedInterface := expectedType.Elem()
+
+	if actualType.Implements(expectedInterface) {
+		return fmt.Sprintf(shouldNotHaveImplemented, actualType, expectedInterface)
+	}
+	return success
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/LICENSE.md
+++ b/vendor/github.com/smartystreets/goconvey/convey/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2016 SmartyStreets, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+NOTE: Various optional and subordinate components carry their own licensing
+requirements and restrictions.  Use of those components is subject to the terms
+and conditions outlined the respective license of each component.

--- a/vendor/github.com/smartystreets/goconvey/convey/assertions.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/assertions.go
@@ -1,0 +1,68 @@
+package convey
+
+import "github.com/smartystreets/assertions"
+
+var (
+	ShouldEqual          = assertions.ShouldEqual
+	ShouldNotEqual       = assertions.ShouldNotEqual
+	ShouldAlmostEqual    = assertions.ShouldAlmostEqual
+	ShouldNotAlmostEqual = assertions.ShouldNotAlmostEqual
+	ShouldResemble       = assertions.ShouldResemble
+	ShouldNotResemble    = assertions.ShouldNotResemble
+	ShouldPointTo        = assertions.ShouldPointTo
+	ShouldNotPointTo     = assertions.ShouldNotPointTo
+	ShouldBeNil          = assertions.ShouldBeNil
+	ShouldNotBeNil       = assertions.ShouldNotBeNil
+	ShouldBeTrue         = assertions.ShouldBeTrue
+	ShouldBeFalse        = assertions.ShouldBeFalse
+	ShouldBeZeroValue    = assertions.ShouldBeZeroValue
+
+	ShouldBeGreaterThan          = assertions.ShouldBeGreaterThan
+	ShouldBeGreaterThanOrEqualTo = assertions.ShouldBeGreaterThanOrEqualTo
+	ShouldBeLessThan             = assertions.ShouldBeLessThan
+	ShouldBeLessThanOrEqualTo    = assertions.ShouldBeLessThanOrEqualTo
+	ShouldBeBetween              = assertions.ShouldBeBetween
+	ShouldNotBeBetween           = assertions.ShouldNotBeBetween
+	ShouldBeBetweenOrEqual       = assertions.ShouldBeBetweenOrEqual
+	ShouldNotBeBetweenOrEqual    = assertions.ShouldNotBeBetweenOrEqual
+
+	ShouldContain       = assertions.ShouldContain
+	ShouldNotContain    = assertions.ShouldNotContain
+	ShouldContainKey    = assertions.ShouldContainKey
+	ShouldNotContainKey = assertions.ShouldNotContainKey
+	ShouldBeIn          = assertions.ShouldBeIn
+	ShouldNotBeIn       = assertions.ShouldNotBeIn
+	ShouldBeEmpty       = assertions.ShouldBeEmpty
+	ShouldNotBeEmpty    = assertions.ShouldNotBeEmpty
+	ShouldHaveLength    = assertions.ShouldHaveLength
+
+	ShouldStartWith           = assertions.ShouldStartWith
+	ShouldNotStartWith        = assertions.ShouldNotStartWith
+	ShouldEndWith             = assertions.ShouldEndWith
+	ShouldNotEndWith          = assertions.ShouldNotEndWith
+	ShouldBeBlank             = assertions.ShouldBeBlank
+	ShouldNotBeBlank          = assertions.ShouldNotBeBlank
+	ShouldContainSubstring    = assertions.ShouldContainSubstring
+	ShouldNotContainSubstring = assertions.ShouldNotContainSubstring
+
+	ShouldPanic        = assertions.ShouldPanic
+	ShouldNotPanic     = assertions.ShouldNotPanic
+	ShouldPanicWith    = assertions.ShouldPanicWith
+	ShouldNotPanicWith = assertions.ShouldNotPanicWith
+
+	ShouldHaveSameTypeAs    = assertions.ShouldHaveSameTypeAs
+	ShouldNotHaveSameTypeAs = assertions.ShouldNotHaveSameTypeAs
+	ShouldImplement         = assertions.ShouldImplement
+	ShouldNotImplement      = assertions.ShouldNotImplement
+
+	ShouldHappenBefore         = assertions.ShouldHappenBefore
+	ShouldHappenOnOrBefore     = assertions.ShouldHappenOnOrBefore
+	ShouldHappenAfter          = assertions.ShouldHappenAfter
+	ShouldHappenOnOrAfter      = assertions.ShouldHappenOnOrAfter
+	ShouldHappenBetween        = assertions.ShouldHappenBetween
+	ShouldHappenOnOrBetween    = assertions.ShouldHappenOnOrBetween
+	ShouldNotHappenOnOrBetween = assertions.ShouldNotHappenOnOrBetween
+	ShouldHappenWithin         = assertions.ShouldHappenWithin
+	ShouldNotHappenWithin      = assertions.ShouldNotHappenWithin
+	ShouldBeChronological      = assertions.ShouldBeChronological
+)

--- a/vendor/github.com/smartystreets/goconvey/convey/context.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/context.go
@@ -1,0 +1,272 @@
+package convey
+
+import (
+	"fmt"
+
+	"github.com/jtolds/gls"
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+type conveyErr struct {
+	fmt    string
+	params []interface{}
+}
+
+func (e *conveyErr) Error() string {
+	return fmt.Sprintf(e.fmt, e.params...)
+}
+
+func conveyPanic(fmt string, params ...interface{}) {
+	panic(&conveyErr{fmt, params})
+}
+
+const (
+	missingGoTest = `Top-level calls to Convey(...) need a reference to the *testing.T.
+		Hint: Convey("description here", t, func() { /* notice that the second argument was the *testing.T (t)! */ }) `
+	extraGoTest    = `Only the top-level call to Convey(...) needs a reference to the *testing.T.`
+	noStackContext = "Convey operation made without context on goroutine stack.\n" +
+		"Hint: Perhaps you meant to use `Convey(..., func(c C){...})` ?"
+	differentConveySituations = "Different set of Convey statements on subsequent pass!\nDid not expect %#v."
+	multipleIdenticalConvey   = "Multiple convey suites with identical names: %#v"
+)
+
+const (
+	failureHalt = "___FAILURE_HALT___"
+
+	nodeKey = "node"
+)
+
+///////////////////////////////// Stack Context /////////////////////////////////
+
+func getCurrentContext() *context {
+	ctx, ok := ctxMgr.GetValue(nodeKey)
+	if ok {
+		return ctx.(*context)
+	}
+	return nil
+}
+
+func mustGetCurrentContext() *context {
+	ctx := getCurrentContext()
+	if ctx == nil {
+		conveyPanic(noStackContext)
+	}
+	return ctx
+}
+
+//////////////////////////////////// Context ////////////////////////////////////
+
+// context magically handles all coordination of Convey's and So assertions.
+//
+// It is tracked on the stack as goroutine-local-storage with the gls package,
+// or explicitly if the user decides to call convey like:
+//
+//   Convey(..., func(c C) {
+//     c.So(...)
+//   })
+//
+// This implements the `C` interface.
+type context struct {
+	reporter reporting.Reporter
+
+	children map[string]*context
+
+	resets []func()
+
+	executedOnce   bool
+	expectChildRun *bool
+	complete       bool
+
+	focus       bool
+	failureMode FailureMode
+}
+
+// rootConvey is the main entry point to a test suite. This is called when
+// there's no context in the stack already, and items must contain a `t` object,
+// or this panics.
+func rootConvey(items ...interface{}) {
+	entry := discover(items)
+
+	if entry.Test == nil {
+		conveyPanic(missingGoTest)
+	}
+
+	expectChildRun := true
+	ctx := &context{
+		reporter: buildReporter(),
+
+		children: make(map[string]*context),
+
+		expectChildRun: &expectChildRun,
+
+		focus:       entry.Focus,
+		failureMode: defaultFailureMode.combine(entry.FailMode),
+	}
+	ctxMgr.SetValues(gls.Values{nodeKey: ctx}, func() {
+		ctx.reporter.BeginStory(reporting.NewStoryReport(entry.Test))
+		defer ctx.reporter.EndStory()
+
+		for ctx.shouldVisit() {
+			ctx.conveyInner(entry.Situation, entry.Func)
+			expectChildRun = true
+		}
+	})
+}
+
+//////////////////////////////////// Methods ////////////////////////////////////
+
+func (ctx *context) SkipConvey(items ...interface{}) {
+	ctx.Convey(items, skipConvey)
+}
+
+func (ctx *context) FocusConvey(items ...interface{}) {
+	ctx.Convey(items, focusConvey)
+}
+
+func (ctx *context) Convey(items ...interface{}) {
+	entry := discover(items)
+
+	// we're a branch, or leaf (on the wind)
+	if entry.Test != nil {
+		conveyPanic(extraGoTest)
+	}
+	if ctx.focus && !entry.Focus {
+		return
+	}
+
+	var inner_ctx *context
+	if ctx.executedOnce {
+		var ok bool
+		inner_ctx, ok = ctx.children[entry.Situation]
+		if !ok {
+			conveyPanic(differentConveySituations, entry.Situation)
+		}
+	} else {
+		if _, ok := ctx.children[entry.Situation]; ok {
+			conveyPanic(multipleIdenticalConvey, entry.Situation)
+		}
+		inner_ctx = &context{
+			reporter: ctx.reporter,
+
+			children: make(map[string]*context),
+
+			expectChildRun: ctx.expectChildRun,
+
+			focus:       entry.Focus,
+			failureMode: ctx.failureMode.combine(entry.FailMode),
+		}
+		ctx.children[entry.Situation] = inner_ctx
+	}
+
+	if inner_ctx.shouldVisit() {
+		ctxMgr.SetValues(gls.Values{nodeKey: inner_ctx}, func() {
+			inner_ctx.conveyInner(entry.Situation, entry.Func)
+		})
+	}
+}
+
+func (ctx *context) SkipSo(stuff ...interface{}) {
+	ctx.assertionReport(reporting.NewSkipReport())
+}
+
+func (ctx *context) So(actual interface{}, assert assertion, expected ...interface{}) {
+	if result := assert(actual, expected...); result == assertionSuccess {
+		ctx.assertionReport(reporting.NewSuccessReport())
+	} else {
+		ctx.assertionReport(reporting.NewFailureReport(result))
+	}
+}
+
+func (ctx *context) Reset(action func()) {
+	/* TODO: Failure mode configuration */
+	ctx.resets = append(ctx.resets, action)
+}
+
+func (ctx *context) Print(items ...interface{}) (int, error) {
+	fmt.Fprint(ctx.reporter, items...)
+	return fmt.Print(items...)
+}
+
+func (ctx *context) Println(items ...interface{}) (int, error) {
+	fmt.Fprintln(ctx.reporter, items...)
+	return fmt.Println(items...)
+}
+
+func (ctx *context) Printf(format string, items ...interface{}) (int, error) {
+	fmt.Fprintf(ctx.reporter, format, items...)
+	return fmt.Printf(format, items...)
+}
+
+//////////////////////////////////// Private ////////////////////////////////////
+
+// shouldVisit returns true iff we should traverse down into a Convey. Note
+// that just because we don't traverse a Convey this time, doesn't mean that
+// we may not traverse it on a subsequent pass.
+func (c *context) shouldVisit() bool {
+	return !c.complete && *c.expectChildRun
+}
+
+// conveyInner is the function which actually executes the user's anonymous test
+// function body. At this point, Convey or RootConvey has decided that this
+// function should actually run.
+func (ctx *context) conveyInner(situation string, f func(C)) {
+	// Record/Reset state for next time.
+	defer func() {
+		ctx.executedOnce = true
+
+		// This is only needed at the leaves, but there's no harm in also setting it
+		// when returning from branch Convey's
+		*ctx.expectChildRun = false
+	}()
+
+	// Set up+tear down our scope for the reporter
+	ctx.reporter.Enter(reporting.NewScopeReport(situation))
+	defer ctx.reporter.Exit()
+
+	// Recover from any panics in f, and assign the `complete` status for this
+	// node of the tree.
+	defer func() {
+		ctx.complete = true
+		if problem := recover(); problem != nil {
+			if problem, ok := problem.(*conveyErr); ok {
+				panic(problem)
+			}
+			if problem != failureHalt {
+				ctx.reporter.Report(reporting.NewErrorReport(problem))
+			}
+		} else {
+			for _, child := range ctx.children {
+				if !child.complete {
+					ctx.complete = false
+					return
+				}
+			}
+		}
+	}()
+
+	// Resets are registered as the `f` function executes, so nil them here.
+	// All resets are run in registration order (FIFO).
+	ctx.resets = []func(){}
+	defer func() {
+		for _, r := range ctx.resets {
+			// panics handled by the previous defer
+			r()
+		}
+	}()
+
+	if f == nil {
+		// if f is nil, this was either a Convey(..., nil), or a SkipConvey
+		ctx.reporter.Report(reporting.NewSkipReport())
+	} else {
+		f(ctx)
+	}
+}
+
+// assertionReport is a helper for So and SkipSo which makes the report and
+// then possibly panics, depending on the current context's failureMode.
+func (ctx *context) assertionReport(r *reporting.AssertionResult) {
+	ctx.reporter.Report(r)
+	if r.Failure != "" && ctx.failureMode == FailureHalts {
+		panic(failureHalt)
+	}
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/discovery.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/discovery.go
@@ -1,0 +1,103 @@
+package convey
+
+type actionSpecifier uint8
+
+const (
+	noSpecifier actionSpecifier = iota
+	skipConvey
+	focusConvey
+)
+
+type suite struct {
+	Situation string
+	Test      t
+	Focus     bool
+	Func      func(C) // nil means skipped
+	FailMode  FailureMode
+}
+
+func newSuite(situation string, failureMode FailureMode, f func(C), test t, specifier actionSpecifier) *suite {
+	ret := &suite{
+		Situation: situation,
+		Test:      test,
+		Func:      f,
+		FailMode:  failureMode,
+	}
+	switch specifier {
+	case skipConvey:
+		ret.Func = nil
+	case focusConvey:
+		ret.Focus = true
+	}
+	return ret
+}
+
+func discover(items []interface{}) *suite {
+	name, items := parseName(items)
+	test, items := parseGoTest(items)
+	failure, items := parseFailureMode(items)
+	action, items := parseAction(items)
+	specifier, items := parseSpecifier(items)
+
+	if len(items) != 0 {
+		conveyPanic(parseError)
+	}
+
+	return newSuite(name, failure, action, test, specifier)
+}
+func item(items []interface{}) interface{} {
+	if len(items) == 0 {
+		conveyPanic(parseError)
+	}
+	return items[0]
+}
+func parseName(items []interface{}) (string, []interface{}) {
+	if name, parsed := item(items).(string); parsed {
+		return name, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+func parseGoTest(items []interface{}) (t, []interface{}) {
+	if test, parsed := item(items).(t); parsed {
+		return test, items[1:]
+	}
+	return nil, items
+}
+func parseFailureMode(items []interface{}) (FailureMode, []interface{}) {
+	if mode, parsed := item(items).(FailureMode); parsed {
+		return mode, items[1:]
+	}
+	return FailureInherits, items
+}
+func parseAction(items []interface{}) (func(C), []interface{}) {
+	switch x := item(items).(type) {
+	case nil:
+		return nil, items[1:]
+	case func(C):
+		return x, items[1:]
+	case func():
+		return func(C) { x() }, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+func parseSpecifier(items []interface{}) (actionSpecifier, []interface{}) {
+	if len(items) == 0 {
+		return noSpecifier, items
+	}
+	if spec, ok := items[0].(actionSpecifier); ok {
+		return spec, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+
+// This interface allows us to pass the *testing.T struct
+// throughout the internals of this package without ever
+// having to import the "testing" package.
+type t interface {
+	Fail()
+}
+
+const parseError = "You must provide a name (string), then a *testing.T (if in outermost scope), an optional FailureMode, and then an action (func())."

--- a/vendor/github.com/smartystreets/goconvey/convey/doc.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/doc.go
@@ -1,0 +1,218 @@
+// Package convey contains all of the public-facing entry points to this project.
+// This means that it should never be required of the user to import any other
+// packages from this project as they serve internal purposes.
+package convey
+
+import "github.com/smartystreets/goconvey/convey/reporting"
+
+////////////////////////////////// suite //////////////////////////////////
+
+// C is the Convey context which you can optionally obtain in your action
+// by calling Convey like:
+//
+//   Convey(..., func(c C) {
+//     ...
+//   })
+//
+// See the documentation on Convey for more details.
+//
+// All methods in this context behave identically to the global functions of the
+// same name in this package.
+type C interface {
+	Convey(items ...interface{})
+	SkipConvey(items ...interface{})
+	FocusConvey(items ...interface{})
+
+	So(actual interface{}, assert assertion, expected ...interface{})
+	SkipSo(stuff ...interface{})
+
+	Reset(action func())
+
+	Println(items ...interface{}) (int, error)
+	Print(items ...interface{}) (int, error)
+	Printf(format string, items ...interface{}) (int, error)
+}
+
+// Convey is the method intended for use when declaring the scopes of
+// a specification. Each scope has a description and a func() which may contain
+// other calls to Convey(), Reset() or Should-style assertions. Convey calls can
+// be nested as far as you see fit.
+//
+// IMPORTANT NOTE: The top-level Convey() within a Test method
+// must conform to the following signature:
+//
+//     Convey(description string, t *testing.T, action func())
+//
+// All other calls should look like this (no need to pass in *testing.T):
+//
+//     Convey(description string, action func())
+//
+// Don't worry, goconvey will panic if you get it wrong so you can fix it.
+//
+// Additionally, you may explicitly obtain access to the Convey context by doing:
+//
+//     Convey(description string, action func(c C))
+//
+// You may need to do this if you want to pass the context through to a
+// goroutine, or to close over the context in a handler to a library which
+// calls your handler in a goroutine (httptest comes to mind).
+//
+// All Convey()-blocks also accept an optional parameter of FailureMode which sets
+// how goconvey should treat failures for So()-assertions in the block and
+// nested blocks. See the constants in this file for the available options.
+//
+// By default it will inherit from its parent block and the top-level blocks
+// default to the FailureHalts setting.
+//
+// This parameter is inserted before the block itself:
+//
+//     Convey(description string, t *testing.T, mode FailureMode, action func())
+//     Convey(description string, mode FailureMode, action func())
+//
+// See the examples package for, well, examples.
+func Convey(items ...interface{}) {
+	if ctx := getCurrentContext(); ctx == nil {
+		rootConvey(items...)
+	} else {
+		ctx.Convey(items...)
+	}
+}
+
+// SkipConvey is analagous to Convey except that the scope is not executed
+// (which means that child scopes defined within this scope are not run either).
+// The reporter will be notified that this step was skipped.
+func SkipConvey(items ...interface{}) {
+	Convey(append(items, skipConvey)...)
+}
+
+// FocusConvey is has the inverse effect of SkipConvey. If the top-level
+// Convey is changed to `FocusConvey`, only nested scopes that are defined
+// with FocusConvey will be run. The rest will be ignored completely. This
+// is handy when debugging a large suite that runs a misbehaving function
+// repeatedly as you can disable all but one of that function
+// without swaths of `SkipConvey` calls, just a targeted chain of calls
+// to FocusConvey.
+func FocusConvey(items ...interface{}) {
+	Convey(append(items, focusConvey)...)
+}
+
+// Reset registers a cleanup function to be run after each Convey()
+// in the same scope. See the examples package for a simple use case.
+func Reset(action func()) {
+	mustGetCurrentContext().Reset(action)
+}
+
+/////////////////////////////////// Assertions ///////////////////////////////////
+
+// assertion is an alias for a function with a signature that the convey.So()
+// method can handle. Any future or custom assertions should conform to this
+// method signature. The return value should be an empty string if the assertion
+// passes and a well-formed failure message if not.
+type assertion func(actual interface{}, expected ...interface{}) string
+
+const assertionSuccess = ""
+
+// So is the means by which assertions are made against the system under test.
+// The majority of exported names in the assertions package begin with the word
+// 'Should' and describe how the first argument (actual) should compare with any
+// of the final (expected) arguments. How many final arguments are accepted
+// depends on the particular assertion that is passed in as the assert argument.
+// See the examples package for use cases and the assertions package for
+// documentation on specific assertion methods. A failing assertion will
+// cause t.Fail() to be invoked--you should never call this method (or other
+// failure-inducing methods) in your test code. Leave that to GoConvey.
+func So(actual interface{}, assert assertion, expected ...interface{}) {
+	mustGetCurrentContext().So(actual, assert, expected...)
+}
+
+// SkipSo is analagous to So except that the assertion that would have been passed
+// to So is not executed and the reporter is notified that the assertion was skipped.
+func SkipSo(stuff ...interface{}) {
+	mustGetCurrentContext().SkipSo()
+}
+
+// FailureMode is a type which determines how the So() blocks should fail
+// if their assertion fails. See constants further down for acceptable values
+type FailureMode string
+
+const (
+
+	// FailureContinues is a failure mode which prevents failing
+	// So()-assertions from halting Convey-block execution, instead
+	// allowing the test to continue past failing So()-assertions.
+	FailureContinues FailureMode = "continue"
+
+	// FailureHalts is the default setting for a top-level Convey()-block
+	// and will cause all failing So()-assertions to halt further execution
+	// in that test-arm and continue on to the next arm.
+	FailureHalts FailureMode = "halt"
+
+	// FailureInherits is the default setting for failure-mode, it will
+	// default to the failure-mode of the parent block. You should never
+	// need to specify this mode in your tests..
+	FailureInherits FailureMode = "inherits"
+)
+
+func (f FailureMode) combine(other FailureMode) FailureMode {
+	if other == FailureInherits {
+		return f
+	}
+	return other
+}
+
+var defaultFailureMode FailureMode = FailureHalts
+
+// SetDefaultFailureMode allows you to specify the default failure mode
+// for all Convey blocks. It is meant to be used in an init function to
+// allow the default mode to be changdd across all tests for an entire packgae
+// but it can be used anywhere.
+func SetDefaultFailureMode(mode FailureMode) {
+	if mode == FailureContinues || mode == FailureHalts {
+		defaultFailureMode = mode
+	} else {
+		panic("You may only use the constants named 'FailureContinues' and 'FailureHalts' as default failure modes.")
+	}
+}
+
+//////////////////////////////////// Print functions ////////////////////////////////////
+
+// Print is analogous to fmt.Print (and it even calls fmt.Print). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Print(items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Print(items...)
+}
+
+// Print is analogous to fmt.Println (and it even calls fmt.Println). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Println(items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Println(items...)
+}
+
+// Print is analogous to fmt.Printf (and it even calls fmt.Printf). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Printf(format string, items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Printf(format, items...)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// SuppressConsoleStatistics prevents automatic printing of console statistics.
+// Calling PrintConsoleStatistics explicitly will force printing of statistics.
+func SuppressConsoleStatistics() {
+	reporting.SuppressConsoleStatistics()
+}
+
+// ConsoleStatistics may be called at any time to print assertion statistics.
+// Generally, the best place to do this would be in a TestMain function,
+// after all tests have been run. Something like this:
+//
+// func TestMain(m *testing.M) {
+//     convey.SuppressConsoleStatistics()
+//     result := m.Run()
+//     convey.PrintConsoleStatistics()
+//     os.Exit(result)
+// }
+//
+func PrintConsoleStatistics() {
+	reporting.PrintConsoleStatistics()
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
@@ -1,0 +1,28 @@
+// Package gotest contains internal functionality. Although this package
+// contains one or more exported names it is not intended for public
+// consumption. See the examples package for how to use this project.
+package gotest
+
+import (
+	"runtime"
+	"strings"
+)
+
+func ResolveExternalCaller() (file string, line int, name string) {
+	var caller_id uintptr
+	callers := runtime.Callers(0, callStack)
+
+	for x := 0; x < callers; x++ {
+		caller_id, file, line, _ = runtime.Caller(x)
+		if strings.HasSuffix(file, "_test.go") || strings.HasSuffix(file, "_tests.go") {
+			name = runtime.FuncForPC(caller_id).Name()
+			return
+		}
+	}
+	file, line, name = "<unkown file>", -1, "<unknown name>"
+	return // panic?
+}
+
+const maxStackDepth = 100 // This had better be enough...
+
+var callStack []uintptr = make([]uintptr, maxStackDepth, maxStackDepth)

--- a/vendor/github.com/smartystreets/goconvey/convey/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/init.go
@@ -1,0 +1,81 @@
+package convey
+
+import (
+	"flag"
+	"os"
+
+	"github.com/jtolds/gls"
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+func init() {
+	assertions.GoConveyMode(true)
+
+	declareFlags()
+
+	ctxMgr = gls.NewContextManager()
+}
+
+func declareFlags() {
+	flag.BoolVar(&json, "convey-json", false, "When true, emits results in JSON blocks. Default: 'false'")
+	flag.BoolVar(&silent, "convey-silent", false, "When true, all output from GoConvey is suppressed.")
+	flag.BoolVar(&story, "convey-story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
+
+	if noStoryFlagProvided() {
+		story = verboseEnabled
+	}
+
+	// FYI: flag.Parse() is called from the testing package.
+}
+
+func noStoryFlagProvided() bool {
+	return !story && !storyDisabled
+}
+
+func buildReporter() reporting.Reporter {
+	selectReporter := os.Getenv("GOCONVEY_REPORTER")
+
+	switch {
+	case testReporter != nil:
+		return testReporter
+	case json || selectReporter == "json":
+		return reporting.BuildJsonReporter()
+	case silent || selectReporter == "silent":
+		return reporting.BuildSilentReporter()
+	case selectReporter == "dot":
+		// Story is turned on when verbose is set, so we need to check for dot reporter first.
+		return reporting.BuildDotReporter()
+	case story || selectReporter == "story":
+		return reporting.BuildStoryReporter()
+	default:
+		return reporting.BuildDotReporter()
+	}
+}
+
+var (
+	ctxMgr *gls.ContextManager
+
+	// only set by internal tests
+	testReporter reporting.Reporter
+)
+
+var (
+	json   bool
+	silent bool
+	story  bool
+
+	verboseEnabled = flagFound("-test.v=true")
+	storyDisabled  = flagFound("-story=false")
+)
+
+// flagFound parses the command line args manually for flags defined in other
+// packages. Like the '-v' flag from the "testing" package, for instance.
+func flagFound(flagValue string) bool {
+	for _, arg := range os.Args {
+		if arg == flagValue {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/nilReporter.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/nilReporter.go
@@ -1,0 +1,15 @@
+package convey
+
+import (
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+type nilReporter struct{}
+
+func (self *nilReporter) BeginStory(story *reporting.StoryReport)  {}
+func (self *nilReporter) Enter(scope *reporting.ScopeReport)       {}
+func (self *nilReporter) Report(report *reporting.AssertionResult) {}
+func (self *nilReporter) Exit()                                    {}
+func (self *nilReporter) EndStory()                                {}
+func (self *nilReporter) Write(p []byte) (int, error)              { return len(p), nil }
+func newNilReporter() *nilReporter                                 { return &nilReporter{} }

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/console.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/console.go
@@ -1,0 +1,16 @@
+package reporting
+
+import (
+	"fmt"
+	"io"
+)
+
+type console struct{}
+
+func (self *console) Write(p []byte) (n int, err error) {
+	return fmt.Print(string(p))
+}
+
+func NewConsole() io.Writer {
+	return new(console)
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/doc.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/doc.go
@@ -1,0 +1,5 @@
+// Package reporting contains internal functionality related
+// to console reporting and output. Although this package has
+// exported names is not intended for public consumption. See the
+// examples package for how to use this project.
+package reporting

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/dot.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/dot.go
@@ -1,0 +1,40 @@
+package reporting
+
+import "fmt"
+
+type dot struct{ out *Printer }
+
+func (self *dot) BeginStory(story *StoryReport) {}
+
+func (self *dot) Enter(scope *ScopeReport) {}
+
+func (self *dot) Report(report *AssertionResult) {
+	if report.Error != nil {
+		fmt.Print(redColor)
+		self.out.Insert(dotError)
+	} else if report.Failure != "" {
+		fmt.Print(yellowColor)
+		self.out.Insert(dotFailure)
+	} else if report.Skipped {
+		fmt.Print(yellowColor)
+		self.out.Insert(dotSkip)
+	} else {
+		fmt.Print(greenColor)
+		self.out.Insert(dotSuccess)
+	}
+	fmt.Print(resetColor)
+}
+
+func (self *dot) Exit() {}
+
+func (self *dot) EndStory() {}
+
+func (self *dot) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewDotReporter(out *Printer) *dot {
+	self := new(dot)
+	self.out = out
+	return self
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/gotest.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/gotest.go
@@ -1,0 +1,33 @@
+package reporting
+
+type gotestReporter struct{ test T }
+
+func (self *gotestReporter) BeginStory(story *StoryReport) {
+	self.test = story.Test
+}
+
+func (self *gotestReporter) Enter(scope *ScopeReport) {}
+
+func (self *gotestReporter) Report(r *AssertionResult) {
+	if !passed(r) {
+		self.test.Fail()
+	}
+}
+
+func (self *gotestReporter) Exit() {}
+
+func (self *gotestReporter) EndStory() {
+	self.test = nil
+}
+
+func (self *gotestReporter) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewGoTestReporter() *gotestReporter {
+	return new(gotestReporter)
+}
+
+func passed(r *AssertionResult) bool {
+	return r.Error == nil && r.Failure == ""
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
@@ -1,0 +1,94 @@
+package reporting
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+func init() {
+	if !isColorableTerminal() {
+		monochrome()
+	}
+
+	if runtime.GOOS == "windows" {
+		success, failure, error_ = dotSuccess, dotFailure, dotError
+	}
+}
+
+func BuildJsonReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewJsonReporter(out))
+}
+func BuildDotReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewDotReporter(out),
+		NewProblemReporter(out),
+		consoleStatistics)
+}
+func BuildStoryReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewStoryReporter(out),
+		NewProblemReporter(out),
+		consoleStatistics)
+}
+func BuildSilentReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewSilentProblemReporter(out))
+}
+
+var (
+	newline         = "\n"
+	success         = "✔"
+	failure         = "✘"
+	error_          = "🔥"
+	skip            = "⚠"
+	dotSuccess      = "."
+	dotFailure      = "x"
+	dotError        = "E"
+	dotSkip         = "S"
+	errorTemplate   = "* %s \nLine %d: - %v \n%s\n"
+	failureTemplate = "* %s \nLine %d:\n%s\n"
+)
+
+var (
+	greenColor  = "\033[32m"
+	yellowColor = "\033[33m"
+	redColor    = "\033[31m"
+	resetColor  = "\033[0m"
+)
+
+var consoleStatistics = NewStatisticsReporter(NewPrinter(NewConsole()))
+
+func SuppressConsoleStatistics() { consoleStatistics.Suppress() }
+func PrintConsoleStatistics()    { consoleStatistics.PrintSummary() }
+
+// QuiteMode disables all console output symbols. This is only meant to be used
+// for tests that are internal to goconvey where the output is distracting or
+// otherwise not needed in the test output.
+func QuietMode() {
+	success, failure, error_, skip, dotSuccess, dotFailure, dotError, dotSkip = "", "", "", "", "", "", "", ""
+}
+
+func monochrome() {
+	greenColor, yellowColor, redColor, resetColor = "", "", "", ""
+}
+
+func isColorableTerminal() bool {
+	return strings.Contains(os.Getenv("TERM"), "color")
+}
+
+// This interface allows us to pass the *testing.T struct
+// throughout the internals of this tool without ever
+// having to import the "testing" package.
+type T interface {
+	Fail()
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/json.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/json.go
@@ -1,0 +1,88 @@
+// TODO: under unit test
+
+package reporting
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type JsonReporter struct {
+	out        *Printer
+	currentKey []string
+	current    *ScopeResult
+	index      map[string]*ScopeResult
+	scopes     []*ScopeResult
+}
+
+func (self *JsonReporter) depth() int { return len(self.currentKey) }
+
+func (self *JsonReporter) BeginStory(story *StoryReport) {}
+
+func (self *JsonReporter) Enter(scope *ScopeReport) {
+	self.currentKey = append(self.currentKey, scope.Title)
+	ID := strings.Join(self.currentKey, "|")
+	if _, found := self.index[ID]; !found {
+		next := newScopeResult(scope.Title, self.depth(), scope.File, scope.Line)
+		self.scopes = append(self.scopes, next)
+		self.index[ID] = next
+	}
+	self.current = self.index[ID]
+}
+
+func (self *JsonReporter) Report(report *AssertionResult) {
+	self.current.Assertions = append(self.current.Assertions, report)
+}
+
+func (self *JsonReporter) Exit() {
+	self.currentKey = self.currentKey[:len(self.currentKey)-1]
+}
+
+func (self *JsonReporter) EndStory() {
+	self.report()
+	self.reset()
+}
+func (self *JsonReporter) report() {
+	scopes := []string{}
+	for _, scope := range self.scopes {
+		serialized, err := json.Marshal(scope)
+		if err != nil {
+			self.out.Println(jsonMarshalFailure)
+			panic(err)
+		}
+		var buffer bytes.Buffer
+		json.Indent(&buffer, serialized, "", "  ")
+		scopes = append(scopes, buffer.String())
+	}
+	self.out.Print(fmt.Sprintf("%s\n%s,\n%s\n", OpenJson, strings.Join(scopes, ","), CloseJson))
+}
+func (self *JsonReporter) reset() {
+	self.scopes = []*ScopeResult{}
+	self.index = map[string]*ScopeResult{}
+	self.currentKey = nil
+}
+
+func (self *JsonReporter) Write(content []byte) (written int, err error) {
+	self.current.Output += string(content)
+	return len(content), nil
+}
+
+func NewJsonReporter(out *Printer) *JsonReporter {
+	self := new(JsonReporter)
+	self.out = out
+	self.reset()
+	return self
+}
+
+const OpenJson = ">->->OPEN-JSON->->->"   // "⌦"
+const CloseJson = "<-<-<-CLOSE-JSON<-<-<" // "⌫"
+const jsonMarshalFailure = `
+
+GOCONVEY_JSON_MARSHALL_FAILURE: There was an error when attempting to convert test results to JSON.
+Please file a bug report and reference the code that caused this failure if possible.
+
+Here's the panic:
+
+`

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
@@ -1,0 +1,57 @@
+package reporting
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Printer struct {
+	out    io.Writer
+	prefix string
+}
+
+func (self *Printer) Println(message string, values ...interface{}) {
+	formatted := self.format(message, values...) + newline
+	self.out.Write([]byte(formatted))
+}
+
+func (self *Printer) Print(message string, values ...interface{}) {
+	formatted := self.format(message, values...)
+	self.out.Write([]byte(formatted))
+}
+
+func (self *Printer) Insert(text string) {
+	self.out.Write([]byte(text))
+}
+
+func (self *Printer) format(message string, values ...interface{}) string {
+	var formatted string
+	if len(values) == 0 {
+		formatted = self.prefix + message
+	} else {
+		formatted = self.prefix + fmt.Sprintf(message, values...)
+	}
+	indented := strings.Replace(formatted, newline, newline+self.prefix, -1)
+	return strings.TrimRight(indented, space)
+}
+
+func (self *Printer) Indent() {
+	self.prefix += pad
+}
+
+func (self *Printer) Dedent() {
+	if len(self.prefix) >= padLength {
+		self.prefix = self.prefix[:len(self.prefix)-padLength]
+	}
+}
+
+func NewPrinter(out io.Writer) *Printer {
+	self := new(Printer)
+	self.out = out
+	return self
+}
+
+const space = " "
+const pad = space + space
+const padLength = len(pad)

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
@@ -1,0 +1,80 @@
+package reporting
+
+import "fmt"
+
+type problem struct {
+	silent   bool
+	out      *Printer
+	errors   []*AssertionResult
+	failures []*AssertionResult
+}
+
+func (self *problem) BeginStory(story *StoryReport) {}
+
+func (self *problem) Enter(scope *ScopeReport) {}
+
+func (self *problem) Report(report *AssertionResult) {
+	if report.Error != nil {
+		self.errors = append(self.errors, report)
+	} else if report.Failure != "" {
+		self.failures = append(self.failures, report)
+	}
+}
+
+func (self *problem) Exit() {}
+
+func (self *problem) EndStory() {
+	self.show(self.showErrors, redColor)
+	self.show(self.showFailures, yellowColor)
+	self.prepareForNextStory()
+}
+func (self *problem) show(display func(), color string) {
+	if !self.silent {
+		fmt.Print(color)
+	}
+	display()
+	if !self.silent {
+		fmt.Print(resetColor)
+	}
+	self.out.Dedent()
+}
+func (self *problem) showErrors() {
+	for i, e := range self.errors {
+		if i == 0 {
+			self.out.Println("\nErrors:\n")
+			self.out.Indent()
+		}
+		self.out.Println(errorTemplate, e.File, e.Line, e.Error, e.StackTrace)
+	}
+}
+func (self *problem) showFailures() {
+	for i, f := range self.failures {
+		if i == 0 {
+			self.out.Println("\nFailures:\n")
+			self.out.Indent()
+		}
+		self.out.Println(failureTemplate, f.File, f.Line, f.Failure)
+	}
+}
+
+func (self *problem) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewProblemReporter(out *Printer) *problem {
+	self := new(problem)
+	self.out = out
+	self.prepareForNextStory()
+	return self
+}
+
+func NewSilentProblemReporter(out *Printer) *problem {
+	self := NewProblemReporter(out)
+	self.silent = true
+	return self
+}
+
+func (self *problem) prepareForNextStory() {
+	self.errors = []*AssertionResult{}
+	self.failures = []*AssertionResult{}
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter.go
@@ -1,0 +1,39 @@
+package reporting
+
+import "io"
+
+type Reporter interface {
+	BeginStory(story *StoryReport)
+	Enter(scope *ScopeReport)
+	Report(r *AssertionResult)
+	Exit()
+	EndStory()
+	io.Writer
+}
+
+type reporters struct{ collection []Reporter }
+
+func (self *reporters) BeginStory(s *StoryReport) { self.foreach(func(r Reporter) { r.BeginStory(s) }) }
+func (self *reporters) Enter(s *ScopeReport)      { self.foreach(func(r Reporter) { r.Enter(s) }) }
+func (self *reporters) Report(a *AssertionResult) { self.foreach(func(r Reporter) { r.Report(a) }) }
+func (self *reporters) Exit()                     { self.foreach(func(r Reporter) { r.Exit() }) }
+func (self *reporters) EndStory()                 { self.foreach(func(r Reporter) { r.EndStory() }) }
+
+func (self *reporters) Write(contents []byte) (written int, err error) {
+	self.foreach(func(r Reporter) {
+		written, err = r.Write(contents)
+	})
+	return written, err
+}
+
+func (self *reporters) foreach(action func(Reporter)) {
+	for _, r := range self.collection {
+		action(r)
+	}
+}
+
+func NewReporters(collection ...Reporter) *reporters {
+	self := new(reporters)
+	self.collection = collection
+	return self
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reports.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reports.go
@@ -1,0 +1,179 @@
+package reporting
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/smartystreets/goconvey/convey/gotest"
+)
+
+////////////////// ScopeReport ////////////////////
+
+type ScopeReport struct {
+	Title string
+	File  string
+	Line  int
+}
+
+func NewScopeReport(title string) *ScopeReport {
+	file, line, _ := gotest.ResolveExternalCaller()
+	self := new(ScopeReport)
+	self.Title = title
+	self.File = file
+	self.Line = line
+	return self
+}
+
+////////////////// ScopeResult ////////////////////
+
+type ScopeResult struct {
+	Title      string
+	File       string
+	Line       int
+	Depth      int
+	Assertions []*AssertionResult
+	Output     string
+}
+
+func newScopeResult(title string, depth int, file string, line int) *ScopeResult {
+	self := new(ScopeResult)
+	self.Title = title
+	self.Depth = depth
+	self.File = file
+	self.Line = line
+	self.Assertions = []*AssertionResult{}
+	return self
+}
+
+/////////////////// StoryReport /////////////////////
+
+type StoryReport struct {
+	Test T
+	Name string
+	File string
+	Line int
+}
+
+func NewStoryReport(test T) *StoryReport {
+	file, line, name := gotest.ResolveExternalCaller()
+	name = removePackagePath(name)
+	self := new(StoryReport)
+	self.Test = test
+	self.Name = name
+	self.File = file
+	self.Line = line
+	return self
+}
+
+// name comes in looking like "github.com/smartystreets/goconvey/examples.TestName".
+// We only want the stuff after the last '.', which is the name of the test function.
+func removePackagePath(name string) string {
+	parts := strings.Split(name, ".")
+	return parts[len(parts)-1]
+}
+
+/////////////////// FailureView ////////////////////////
+
+// This struct is also declared in github.com/smartystreets/assertions.
+// The json struct tags should be equal in both declarations.
+type FailureView struct {
+	Message  string `json:"Message"`
+	Expected string `json:"Expected"`
+	Actual   string `json:"Actual"`
+}
+
+////////////////////AssertionResult //////////////////////
+
+type AssertionResult struct {
+	File       string
+	Line       int
+	Expected   string
+	Actual     string
+	Failure    string
+	Error      interface{}
+	StackTrace string
+	Skipped    bool
+}
+
+func NewFailureReport(failure string) *AssertionResult {
+	report := new(AssertionResult)
+	report.File, report.Line = caller()
+	report.StackTrace = stackTrace()
+	parseFailure(failure, report)
+	return report
+}
+func parseFailure(failure string, report *AssertionResult) {
+	view := new(FailureView)
+	err := json.Unmarshal([]byte(failure), view)
+	if err == nil {
+		report.Failure = view.Message
+		report.Expected = view.Expected
+		report.Actual = view.Actual
+	} else {
+		report.Failure = failure
+	}
+}
+func NewErrorReport(err interface{}) *AssertionResult {
+	report := new(AssertionResult)
+	report.File, report.Line = caller()
+	report.StackTrace = fullStackTrace()
+	report.Error = fmt.Sprintf("%v", err)
+	return report
+}
+func NewSuccessReport() *AssertionResult {
+	return new(AssertionResult)
+}
+func NewSkipReport() *AssertionResult {
+	report := new(AssertionResult)
+	report.File, report.Line = caller()
+	report.StackTrace = fullStackTrace()
+	report.Skipped = true
+	return report
+}
+
+func caller() (file string, line int) {
+	file, line, _ = gotest.ResolveExternalCaller()
+	return
+}
+
+func stackTrace() string {
+	buffer := make([]byte, 1024*64)
+	n := runtime.Stack(buffer, false)
+	return removeInternalEntries(string(buffer[:n]))
+}
+func fullStackTrace() string {
+	buffer := make([]byte, 1024*64)
+	n := runtime.Stack(buffer, true)
+	return removeInternalEntries(string(buffer[:n]))
+}
+func removeInternalEntries(stack string) string {
+	lines := strings.Split(stack, newline)
+	filtered := []string{}
+	for _, line := range lines {
+		if !isExternal(line) {
+			filtered = append(filtered, line)
+		}
+	}
+	return strings.Join(filtered, newline)
+}
+func isExternal(line string) bool {
+	for _, p := range internalPackages {
+		if strings.Contains(line, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// NOTE: any new packages that host goconvey packages will need to be added here!
+// An alternative is to scan the goconvey directory and then exclude stuff like
+// the examples package but that's nasty too.
+var internalPackages = []string{
+	"goconvey/assertions",
+	"goconvey/convey",
+	"goconvey/execution",
+	"goconvey/gotest",
+	"goconvey/reporting",
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/statistics.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/statistics.go
@@ -1,0 +1,108 @@
+package reporting
+
+import (
+	"fmt"
+	"sync"
+)
+
+func (self *statistics) BeginStory(story *StoryReport) {}
+
+func (self *statistics) Enter(scope *ScopeReport) {}
+
+func (self *statistics) Report(report *AssertionResult) {
+	self.Lock()
+	defer self.Unlock()
+
+	if !self.failing && report.Failure != "" {
+		self.failing = true
+	}
+	if !self.erroring && report.Error != nil {
+		self.erroring = true
+	}
+	if report.Skipped {
+		self.skipped += 1
+	} else {
+		self.total++
+	}
+}
+
+func (self *statistics) Exit() {}
+
+func (self *statistics) EndStory() {
+	self.Lock()
+	defer self.Unlock()
+
+	if !self.suppressed {
+		self.printSummaryLocked()
+	}
+}
+
+func (self *statistics) Suppress() {
+	self.Lock()
+	defer self.Unlock()
+	self.suppressed = true
+}
+
+func (self *statistics) PrintSummary() {
+	self.Lock()
+	defer self.Unlock()
+	self.printSummaryLocked()
+}
+
+func (self *statistics) printSummaryLocked() {
+	self.reportAssertionsLocked()
+	self.reportSkippedSectionsLocked()
+	self.completeReportLocked()
+}
+func (self *statistics) reportAssertionsLocked() {
+	self.decideColorLocked()
+	self.out.Print("\n%d total %s", self.total, plural("assertion", self.total))
+}
+func (self *statistics) decideColorLocked() {
+	if self.failing && !self.erroring {
+		fmt.Print(yellowColor)
+	} else if self.erroring {
+		fmt.Print(redColor)
+	} else {
+		fmt.Print(greenColor)
+	}
+}
+func (self *statistics) reportSkippedSectionsLocked() {
+	if self.skipped > 0 {
+		fmt.Print(yellowColor)
+		self.out.Print(" (one or more sections skipped)")
+	}
+}
+func (self *statistics) completeReportLocked() {
+	fmt.Print(resetColor)
+	self.out.Print("\n")
+	self.out.Print("\n")
+}
+
+func (self *statistics) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewStatisticsReporter(out *Printer) *statistics {
+	self := statistics{}
+	self.out = out
+	return &self
+}
+
+type statistics struct {
+	sync.Mutex
+
+	out        *Printer
+	total      int
+	failing    bool
+	erroring   bool
+	skipped    int
+	suppressed bool
+}
+
+func plural(word string, count int) string {
+	if count == 1 {
+		return word
+	}
+	return word + "s"
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/story.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/story.go
@@ -1,0 +1,73 @@
+// TODO: in order for this reporter to be completely honest
+// we need to retrofit to be more like the json reporter such that:
+// 1. it maintains ScopeResult collections, which count assertions
+// 2. it reports only after EndStory(), so that all tick marks
+//    are placed near the appropriate title.
+// 3. Under unit test
+
+package reporting
+
+import (
+	"fmt"
+	"strings"
+)
+
+type story struct {
+	out        *Printer
+	titlesById map[string]string
+	currentKey []string
+}
+
+func (self *story) BeginStory(story *StoryReport) {}
+
+func (self *story) Enter(scope *ScopeReport) {
+	self.out.Indent()
+
+	self.currentKey = append(self.currentKey, scope.Title)
+	ID := strings.Join(self.currentKey, "|")
+
+	if _, found := self.titlesById[ID]; !found {
+		self.out.Println("")
+		self.out.Print(scope.Title)
+		self.out.Insert(" ")
+		self.titlesById[ID] = scope.Title
+	}
+}
+
+func (self *story) Report(report *AssertionResult) {
+	if report.Error != nil {
+		fmt.Print(redColor)
+		self.out.Insert(error_)
+	} else if report.Failure != "" {
+		fmt.Print(yellowColor)
+		self.out.Insert(failure)
+	} else if report.Skipped {
+		fmt.Print(yellowColor)
+		self.out.Insert(skip)
+	} else {
+		fmt.Print(greenColor)
+		self.out.Insert(success)
+	}
+	fmt.Print(resetColor)
+}
+
+func (self *story) Exit() {
+	self.out.Dedent()
+	self.currentKey = self.currentKey[:len(self.currentKey)-1]
+}
+
+func (self *story) EndStory() {
+	self.titlesById = make(map[string]string)
+	self.out.Println("\n")
+}
+
+func (self *story) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewStoryReporter(out *Printer) *story {
+	self := new(story)
+	self.out = out
+	self.titlesById = make(map[string]string)
+	return self
+}

--- a/vendor/golang.org/x/net/context/LICENSE
+++ b/vendor/golang.org/x/net/context/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/net/context/context.go
+++ b/vendor/golang.org/x/net/context/context.go
@@ -1,0 +1,156 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package context defines the Context type, which carries deadlines,
+// cancelation signals, and other request-scoped values across API boundaries
+// and between processes.
+//
+// Incoming requests to a server should create a Context, and outgoing calls to
+// servers should accept a Context.  The chain of function calls between must
+// propagate the Context, optionally replacing it with a modified copy created
+// using WithDeadline, WithTimeout, WithCancel, or WithValue.
+//
+// Programs that use Contexts should follow these rules to keep interfaces
+// consistent across packages and enable static analysis tools to check context
+// propagation:
+//
+// Do not store Contexts inside a struct type; instead, pass a Context
+// explicitly to each function that needs it.  The Context should be the first
+// parameter, typically named ctx:
+//
+// 	func DoSomething(ctx context.Context, arg Arg) error {
+// 		// ... use ctx ...
+// 	}
+//
+// Do not pass a nil Context, even if a function permits it.  Pass context.TODO
+// if you are unsure about which Context to use.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+//
+// The same Context may be passed to functions running in different goroutines;
+// Contexts are safe for simultaneous use by multiple goroutines.
+//
+// See http://blog.golang.org/context for example code for a server that uses
+// Contexts.
+package context // import "golang.org/x/net/context"
+
+import "time"
+
+// A Context carries a deadline, a cancelation signal, and other values across
+// API boundaries.
+//
+// Context's methods may be called by multiple goroutines simultaneously.
+type Context interface {
+	// Deadline returns the time when work done on behalf of this context
+	// should be canceled.  Deadline returns ok==false when no deadline is
+	// set.  Successive calls to Deadline return the same results.
+	Deadline() (deadline time.Time, ok bool)
+
+	// Done returns a channel that's closed when work done on behalf of this
+	// context should be canceled.  Done may return nil if this context can
+	// never be canceled.  Successive calls to Done return the same value.
+	//
+	// WithCancel arranges for Done to be closed when cancel is called;
+	// WithDeadline arranges for Done to be closed when the deadline
+	// expires; WithTimeout arranges for Done to be closed when the timeout
+	// elapses.
+	//
+	// Done is provided for use in select statements:
+	//
+	//  // Stream generates values with DoSomething and sends them to out
+	//  // until DoSomething returns an error or ctx.Done is closed.
+	//  func Stream(ctx context.Context, out chan<- Value) error {
+	//  	for {
+	//  		v, err := DoSomething(ctx)
+	//  		if err != nil {
+	//  			return err
+	//  		}
+	//  		select {
+	//  		case <-ctx.Done():
+	//  			return ctx.Err()
+	//  		case out <- v:
+	//  		}
+	//  	}
+	//  }
+	//
+	// See http://blog.golang.org/pipelines for more examples of how to use
+	// a Done channel for cancelation.
+	Done() <-chan struct{}
+
+	// Err returns a non-nil error value after Done is closed.  Err returns
+	// Canceled if the context was canceled or DeadlineExceeded if the
+	// context's deadline passed.  No other values for Err are defined.
+	// After Done is closed, successive calls to Err return the same value.
+	Err() error
+
+	// Value returns the value associated with this context for key, or nil
+	// if no value is associated with key.  Successive calls to Value with
+	// the same key returns the same result.
+	//
+	// Use context values only for request-scoped data that transits
+	// processes and API boundaries, not for passing optional parameters to
+	// functions.
+	//
+	// A key identifies a specific value in a Context.  Functions that wish
+	// to store values in Context typically allocate a key in a global
+	// variable then use that key as the argument to context.WithValue and
+	// Context.Value.  A key can be any type that supports equality;
+	// packages should define keys as an unexported type to avoid
+	// collisions.
+	//
+	// Packages that define a Context key should provide type-safe accessors
+	// for the values stores using that key:
+	//
+	// 	// Package user defines a User type that's stored in Contexts.
+	// 	package user
+	//
+	// 	import "golang.org/x/net/context"
+	//
+	// 	// User is the type of value stored in the Contexts.
+	// 	type User struct {...}
+	//
+	// 	// key is an unexported type for keys defined in this package.
+	// 	// This prevents collisions with keys defined in other packages.
+	// 	type key int
+	//
+	// 	// userKey is the key for user.User values in Contexts.  It is
+	// 	// unexported; clients use user.NewContext and user.FromContext
+	// 	// instead of using this key directly.
+	// 	var userKey key = 0
+	//
+	// 	// NewContext returns a new Context that carries value u.
+	// 	func NewContext(ctx context.Context, u *User) context.Context {
+	// 		return context.WithValue(ctx, userKey, u)
+	// 	}
+	//
+	// 	// FromContext returns the User value stored in ctx, if any.
+	// 	func FromContext(ctx context.Context) (*User, bool) {
+	// 		u, ok := ctx.Value(userKey).(*User)
+	// 		return u, ok
+	// 	}
+	Value(key interface{}) interface{}
+}
+
+// Background returns a non-nil, empty Context. It is never canceled, has no
+// values, and has no deadline.  It is typically used by the main function,
+// initialization, and tests, and as the top-level Context for incoming
+// requests.
+func Background() Context {
+	return background
+}
+
+// TODO returns a non-nil, empty Context.  Code should use context.TODO when
+// it's unclear which Context to use or it is not yet available (because the
+// surrounding function has not yet been extended to accept a Context
+// parameter).  TODO is recognized by static analysis tools that determine
+// whether Contexts are propagated correctly in a program.
+func TODO() Context {
+	return todo
+}
+
+// A CancelFunc tells an operation to abandon its work.
+// A CancelFunc does not wait for the work to stop.
+// After the first call, subsequent calls to a CancelFunc do nothing.
+type CancelFunc func()

--- a/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
+++ b/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
@@ -1,0 +1,146 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ctxhttp provides helper functions for performing context-aware HTTP requests.
+package ctxhttp // import "golang.org/x/net/context/ctxhttp"
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+func nop() {}
+
+var (
+	testHookContextDoneBeforeHeaders = nop
+	testHookDoReturned               = nop
+	testHookDidBodyClose             = nop
+)
+
+// Do sends an HTTP request with the provided http.Client and returns an HTTP response.
+// If the client is nil, http.DefaultClient is used.
+// If the context is canceled or times out, ctx.Err() will be returned.
+func Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// TODO(djd): Respect any existing value of req.Cancel.
+	cancel := make(chan struct{})
+	req.Cancel = cancel
+
+	type responseAndError struct {
+		resp *http.Response
+		err  error
+	}
+	result := make(chan responseAndError, 1)
+
+	// Make local copies of test hooks closed over by goroutines below.
+	// Prevents data races in tests.
+	testHookDoReturned := testHookDoReturned
+	testHookDidBodyClose := testHookDidBodyClose
+
+	go func() {
+		resp, err := client.Do(req)
+		testHookDoReturned()
+		result <- responseAndError{resp, err}
+	}()
+
+	var resp *http.Response
+
+	select {
+	case <-ctx.Done():
+		testHookContextDoneBeforeHeaders()
+		close(cancel)
+		// Clean up after the goroutine calling client.Do:
+		go func() {
+			if r := <-result; r.resp != nil {
+				testHookDidBodyClose()
+				r.resp.Body.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	case r := <-result:
+		var err error
+		resp, err = r.resp, r.err
+		if err != nil {
+			return resp, err
+		}
+	}
+
+	c := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			close(cancel)
+		case <-c:
+			// The response's Body is closed.
+		}
+	}()
+	resp.Body = &notifyingReader{resp.Body, c}
+
+	return resp, nil
+}
+
+// Get issues a GET request via the Do function.
+func Get(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Head issues a HEAD request via the Do function.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Post issues a POST request via the Do function.
+func Post(ctx context.Context, client *http.Client, url string, bodyType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return Do(ctx, client, req)
+}
+
+// PostForm issues a POST request via the Do function.
+func PostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	return Post(ctx, client, url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}
+
+// notifyingReader is an io.ReadCloser that closes the notify channel after
+// Close is called or a Read fails on the underlying ReadCloser.
+type notifyingReader struct {
+	io.ReadCloser
+	notify chan<- struct{}
+}
+
+func (r *notifyingReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err != nil && r.notify != nil {
+		close(r.notify)
+		r.notify = nil
+	}
+	return n, err
+}
+
+func (r *notifyingReader) Close() error {
+	err := r.ReadCloser.Close()
+	if r.notify != nil {
+		close(r.notify)
+		r.notify = nil
+	}
+	return err
+}

--- a/vendor/golang.org/x/net/context/go17.go
+++ b/vendor/golang.org/x/net/context/go17.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package context
+
+import (
+	"context" // standard library's context, as of Go 1.7
+	"time"
+)
+
+var (
+	todo       = context.TODO()
+	background = context.Background()
+)
+
+// Canceled is the error returned by Context.Err when the context is canceled.
+var Canceled = context.Canceled
+
+// DeadlineExceeded is the error returned by Context.Err when the context's
+// deadline passes.
+var DeadlineExceeded = context.DeadlineExceeded
+
+// WithCancel returns a copy of parent with a new Done channel. The returned
+// context's Done channel is closed when the returned cancel function is called
+// or when the parent context's Done channel is closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
+	ctx, f := context.WithCancel(parent)
+	return ctx, CancelFunc(f)
+}
+
+// WithDeadline returns a copy of the parent context with the deadline adjusted
+// to be no later than d.  If the parent's deadline is already earlier than d,
+// WithDeadline(parent, d) is semantically equivalent to parent.  The returned
+// context's Done channel is closed when the deadline expires, when the returned
+// cancel function is called, or when the parent context's Done channel is
+// closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithDeadline(parent Context, deadline time.Time) (Context, CancelFunc) {
+	ctx, f := context.WithDeadline(parent, deadline)
+	return ctx, CancelFunc(f)
+}
+
+// WithTimeout returns WithDeadline(parent, time.Now().Add(timeout)).
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete:
+//
+// 	func slowOperationWithTimeout(ctx context.Context) (Result, error) {
+// 		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+// 		defer cancel()  // releases resources if slowOperation completes before timeout elapses
+// 		return slowOperation(ctx)
+// 	}
+func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
+	return WithDeadline(parent, time.Now().Add(timeout))
+}
+
+// WithValue returns a copy of parent in which the value associated with key is
+// val.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+func WithValue(parent Context, key interface{}, val interface{}) Context {
+	return context.WithValue(parent, key, val)
+}

--- a/vendor/golang.org/x/net/context/pre_go17.go
+++ b/vendor/golang.org/x/net/context/pre_go17.go
@@ -1,0 +1,300 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package context
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// An emptyCtx is never canceled, has no values, and has no deadline.  It is not
+// struct{}, since vars of this type must have distinct addresses.
+type emptyCtx int
+
+func (*emptyCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (*emptyCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (*emptyCtx) Err() error {
+	return nil
+}
+
+func (*emptyCtx) Value(key interface{}) interface{} {
+	return nil
+}
+
+func (e *emptyCtx) String() string {
+	switch e {
+	case background:
+		return "context.Background"
+	case todo:
+		return "context.TODO"
+	}
+	return "unknown empty Context"
+}
+
+var (
+	background = new(emptyCtx)
+	todo       = new(emptyCtx)
+)
+
+// Canceled is the error returned by Context.Err when the context is canceled.
+var Canceled = errors.New("context canceled")
+
+// DeadlineExceeded is the error returned by Context.Err when the context's
+// deadline passes.
+var DeadlineExceeded = errors.New("context deadline exceeded")
+
+// WithCancel returns a copy of parent with a new Done channel. The returned
+// context's Done channel is closed when the returned cancel function is called
+// or when the parent context's Done channel is closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
+	c := newCancelCtx(parent)
+	propagateCancel(parent, c)
+	return c, func() { c.cancel(true, Canceled) }
+}
+
+// newCancelCtx returns an initialized cancelCtx.
+func newCancelCtx(parent Context) *cancelCtx {
+	return &cancelCtx{
+		Context: parent,
+		done:    make(chan struct{}),
+	}
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent Context, child canceler) {
+	if parent.Done() == nil {
+		return // parent is never canceled
+	}
+	if p, ok := parentCancelCtx(parent); ok {
+		p.mu.Lock()
+		if p.err != nil {
+			// parent has already been canceled
+			child.cancel(false, p.err)
+		} else {
+			if p.children == nil {
+				p.children = make(map[canceler]bool)
+			}
+			p.children[child] = true
+		}
+		p.mu.Unlock()
+	} else {
+		go func() {
+			select {
+			case <-parent.Done():
+				child.cancel(false, parent.Err())
+			case <-child.Done():
+			}
+		}()
+	}
+}
+
+// parentCancelCtx follows a chain of parent references until it finds a
+// *cancelCtx.  This function understands how each of the concrete types in this
+// package represents its parent.
+func parentCancelCtx(parent Context) (*cancelCtx, bool) {
+	for {
+		switch c := parent.(type) {
+		case *cancelCtx:
+			return c, true
+		case *timerCtx:
+			return c.cancelCtx, true
+		case *valueCtx:
+			parent = c.Context
+		default:
+			return nil, false
+		}
+	}
+}
+
+// removeChild removes a context from its parent.
+func removeChild(parent Context, child canceler) {
+	p, ok := parentCancelCtx(parent)
+	if !ok {
+		return
+	}
+	p.mu.Lock()
+	if p.children != nil {
+		delete(p.children, child)
+	}
+	p.mu.Unlock()
+}
+
+// A canceler is a context type that can be canceled directly.  The
+// implementations are *cancelCtx and *timerCtx.
+type canceler interface {
+	cancel(removeFromParent bool, err error)
+	Done() <-chan struct{}
+}
+
+// A cancelCtx can be canceled.  When canceled, it also cancels any children
+// that implement canceler.
+type cancelCtx struct {
+	Context
+
+	done chan struct{} // closed by the first cancel call.
+
+	mu       sync.Mutex
+	children map[canceler]bool // set to nil by the first cancel call
+	err      error             // set to non-nil by the first cancel call
+}
+
+func (c *cancelCtx) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *cancelCtx) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *cancelCtx) String() string {
+	return fmt.Sprintf("%v.WithCancel", c.Context)
+}
+
+// cancel closes c.done, cancels each of c's children, and, if
+// removeFromParent is true, removes c from its parent's children.
+func (c *cancelCtx) cancel(removeFromParent bool, err error) {
+	if err == nil {
+		panic("context: internal error: missing cancel error")
+	}
+	c.mu.Lock()
+	if c.err != nil {
+		c.mu.Unlock()
+		return // already canceled
+	}
+	c.err = err
+	close(c.done)
+	for child := range c.children {
+		// NOTE: acquiring the child's lock while holding parent's lock.
+		child.cancel(false, err)
+	}
+	c.children = nil
+	c.mu.Unlock()
+
+	if removeFromParent {
+		removeChild(c.Context, c)
+	}
+}
+
+// WithDeadline returns a copy of the parent context with the deadline adjusted
+// to be no later than d.  If the parent's deadline is already earlier than d,
+// WithDeadline(parent, d) is semantically equivalent to parent.  The returned
+// context's Done channel is closed when the deadline expires, when the returned
+// cancel function is called, or when the parent context's Done channel is
+// closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithDeadline(parent Context, deadline time.Time) (Context, CancelFunc) {
+	if cur, ok := parent.Deadline(); ok && cur.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return WithCancel(parent)
+	}
+	c := &timerCtx{
+		cancelCtx: newCancelCtx(parent),
+		deadline:  deadline,
+	}
+	propagateCancel(parent, c)
+	d := deadline.Sub(time.Now())
+	if d <= 0 {
+		c.cancel(true, DeadlineExceeded) // deadline has already passed
+		return c, func() { c.cancel(true, Canceled) }
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err == nil {
+		c.timer = time.AfterFunc(d, func() {
+			c.cancel(true, DeadlineExceeded)
+		})
+	}
+	return c, func() { c.cancel(true, Canceled) }
+}
+
+// A timerCtx carries a timer and a deadline.  It embeds a cancelCtx to
+// implement Done and Err.  It implements cancel by stopping its timer then
+// delegating to cancelCtx.cancel.
+type timerCtx struct {
+	*cancelCtx
+	timer *time.Timer // Under cancelCtx.mu.
+
+	deadline time.Time
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) {
+	return c.deadline, true
+}
+
+func (c *timerCtx) String() string {
+	return fmt.Sprintf("%v.WithDeadline(%s [%s])", c.cancelCtx.Context, c.deadline, c.deadline.Sub(time.Now()))
+}
+
+func (c *timerCtx) cancel(removeFromParent bool, err error) {
+	c.cancelCtx.cancel(false, err)
+	if removeFromParent {
+		// Remove this timerCtx from its parent cancelCtx's children.
+		removeChild(c.cancelCtx.Context, c)
+	}
+	c.mu.Lock()
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+	c.mu.Unlock()
+}
+
+// WithTimeout returns WithDeadline(parent, time.Now().Add(timeout)).
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete:
+//
+// 	func slowOperationWithTimeout(ctx context.Context) (Result, error) {
+// 		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+// 		defer cancel()  // releases resources if slowOperation completes before timeout elapses
+// 		return slowOperation(ctx)
+// 	}
+func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
+	return WithDeadline(parent, time.Now().Add(timeout))
+}
+
+// WithValue returns a copy of parent in which the value associated with key is
+// val.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+func WithValue(parent Context, key interface{}, val interface{}) Context {
+	return &valueCtx{parent, key, val}
+}
+
+// A valueCtx carries a key-value pair.  It implements Value for that key and
+// delegates all other calls to the embedded Context.
+type valueCtx struct {
+	Context
+	key, val interface{}
+}
+
+func (c *valueCtx) String() string {
+	return fmt.Sprintf("%v.WithValue(%#v, %#v)", c.Context, c.key, c.val)
+}
+
+func (c *valueCtx) Value(key interface{}) interface{} {
+	if c.key == key {
+		return c.val
+	}
+	return c.Context.Value(key)
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -21,7 +21,7 @@
 			"importpath": "github.com/bebanjo/elastigo",
 			"repository": "https://github.com/bebanjo/elastigo",
 			"vcs": "git",
-			"revision": "eb64079846b888e991940f69b5df6904722ff988",
+			"revision": "2f9d593fb3792c4b6e3328f469ebb0df62ac1ce2",
 			"branch": "master",
 			"notests": true
 		},

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -4,6 +4,7 @@
 		{
 			"importpath": "github.com/BurntSushi/toml",
 			"repository": "https://github.com/BurntSushi/toml",
+			"vcs": "",
 			"revision": "bbd5bb678321a0d6e58f1099321dfa73391c1b6f",
 			"branch": "master",
 			"notests": true
@@ -11,6 +12,7 @@
 		{
 			"importpath": "github.com/araddon/gou",
 			"repository": "https://github.com/araddon/gou",
+			"vcs": "",
 			"revision": "c4d51044125da629d6f2aa594f25b45c451a7d2a",
 			"branch": "master",
 			"notests": true
@@ -18,35 +20,65 @@
 		{
 			"importpath": "github.com/bebanjo/elastigo",
 			"repository": "https://github.com/bebanjo/elastigo",
-			"revision": "5adf312e46cae88115a18f16eb9965bddd1c87f7",
+			"vcs": "git",
+			"revision": "eb64079846b888e991940f69b5df6904722ff988",
 			"branch": "master",
 			"notests": true
 		},
 		{
 			"importpath": "github.com/bitly/go-hostpool",
 			"repository": "https://github.com/bitly/go-hostpool",
+			"vcs": "",
 			"revision": "d0e59c22a56e8dadfed24f74f452cea5a52722d2",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/bmizerany/assert",
+			"repository": "https://github.com/bmizerany/assert",
+			"vcs": "git",
+			"revision": "b7ed37b82869576c289d7d97fb2bbd8b64a0cb28",
 			"branch": "master",
 			"notests": true
 		},
 		{
 			"importpath": "github.com/cpuguy83/go-md2man/md2man",
 			"repository": "https://github.com/cpuguy83/go-md2man",
+			"vcs": "",
 			"revision": "2724a9c9051aa62e9cca11304e7dd518e9e41599",
 			"branch": "master",
 			"path": "/md2man",
 			"notests": true
 		},
 		{
+			"importpath": "github.com/gopherjs/gopherjs/js",
+			"repository": "https://github.com/gopherjs/gopherjs",
+			"vcs": "git",
+			"revision": "6a1c576b7adbb8ddf3a044df225011148fcc0e49",
+			"branch": "master",
+			"path": "/js",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/hashicorp/hcl",
 			"repository": "https://github.com/hashicorp/hcl",
+			"vcs": "",
 			"revision": "2604f3bda7e8960c1be1063709e7d7f0765048d0",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/jtolds/gls",
+			"repository": "https://github.com/jtolds/gls",
+			"vcs": "git",
+			"revision": "8ddce2a84170772b95dd5d576c48d517b22cac63",
 			"branch": "master",
 			"notests": true
 		},
 		{
 			"importpath": "github.com/kr/pretty",
 			"repository": "https://github.com/kr/pretty",
+			"vcs": "",
 			"revision": "add1dbc86daf0f983cd4a48ceb39deb95c729b67",
 			"branch": "master",
 			"notests": true
@@ -54,6 +86,7 @@
 		{
 			"importpath": "github.com/kr/text",
 			"repository": "https://github.com/kr/text",
+			"vcs": "",
 			"revision": "bb797dc4fb8320488f47bf11de07a733d7233e1f",
 			"branch": "master",
 			"notests": true
@@ -61,6 +94,7 @@
 		{
 			"importpath": "github.com/magiconair/properties",
 			"repository": "https://github.com/magiconair/properties",
+			"vcs": "",
 			"revision": "c265cfa48dda6474e208715ca93e987829f572f8",
 			"branch": "master",
 			"notests": true
@@ -68,6 +102,7 @@
 		{
 			"importpath": "github.com/mattbaird/elastigo/lib",
 			"repository": "https://github.com/mattbaird/elastigo",
+			"vcs": "",
 			"revision": "d0839da905fef1221e2b19ddfaf34985add62e10",
 			"branch": "master",
 			"path": "/lib",
@@ -76,6 +111,7 @@
 		{
 			"importpath": "github.com/mitchellh/mapstructure",
 			"repository": "https://github.com/mitchellh/mapstructure",
+			"vcs": "",
 			"revision": "d2dd0262208475919e1a362f675cfc0e7c10e905",
 			"branch": "master",
 			"notests": true
@@ -83,6 +119,7 @@
 		{
 			"importpath": "github.com/russross/blackfriday",
 			"repository": "https://github.com/russross/blackfriday",
+			"vcs": "",
 			"revision": "b43df972fb5fdf3af8d2e90f38a69d374fe26dd0",
 			"branch": "master",
 			"notests": true
@@ -90,13 +127,32 @@
 		{
 			"importpath": "github.com/shurcooL/sanitized_anchor_name",
 			"repository": "https://github.com/shurcooL/sanitized_anchor_name",
+			"vcs": "",
 			"revision": "10ef21a441db47d8b13ebcc5fd2310f636973c77",
 			"branch": "master",
 			"notests": true
 		},
 		{
+			"importpath": "github.com/smartystreets/assertions",
+			"repository": "https://github.com/smartystreets/assertions",
+			"vcs": "git",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/smartystreets/goconvey/convey",
+			"repository": "https://github.com/smartystreets/goconvey",
+			"vcs": "git",
+			"revision": "c53abc99456fa3402dd33c15ee51c3e545e04a3f",
+			"branch": "master",
+			"path": "/convey",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/spf13/cast",
 			"repository": "https://github.com/spf13/cast",
+			"vcs": "",
 			"revision": "27b586b42e29bec072fe7379259cc719e1289da6",
 			"branch": "master",
 			"notests": true
@@ -104,6 +160,7 @@
 		{
 			"importpath": "github.com/spf13/cobra",
 			"repository": "https://github.com/spf13/cobra",
+			"vcs": "",
 			"revision": "4c05eb1145f16d0e6bb4a3e1b6d769f4713cb41f",
 			"branch": "master",
 			"notests": true
@@ -111,6 +168,7 @@
 		{
 			"importpath": "github.com/spf13/jwalterweatherman",
 			"repository": "https://github.com/spf13/jwalterweatherman",
+			"vcs": "",
 			"revision": "33c24e77fb80341fe7130ee7c594256ff08ccc46",
 			"branch": "master",
 			"notests": true
@@ -118,6 +176,7 @@
 		{
 			"importpath": "github.com/spf13/pflag",
 			"repository": "https://github.com/spf13/pflag",
+			"vcs": "",
 			"revision": "1f296710f879815ad9e6d39d947c828c3e4b4c3d",
 			"branch": "master",
 			"notests": true
@@ -125,13 +184,24 @@
 		{
 			"importpath": "github.com/spf13/viper",
 			"repository": "https://github.com/spf13/viper",
+			"vcs": "",
 			"revision": "c975dc1b4eacf4ec7fdbf0873638de5d090ba323",
 			"branch": "master",
 			"notests": true
 		},
 		{
+			"importpath": "golang.org/x/net/context",
+			"repository": "https://go.googlesource.com/net",
+			"vcs": "git",
+			"revision": "b400c2eff1badec7022a8c8f5bea058b6315eed7",
+			"branch": "master",
+			"path": "/context",
+			"notests": true
+		},
+		{
 			"importpath": "gopkg.in/fsnotify.v1",
 			"repository": "https://gopkg.in/fsnotify.v1",
+			"vcs": "",
 			"revision": "875cf421b32f8f1b31bd43776297876d01542279",
 			"branch": "master",
 			"notests": true
@@ -139,6 +209,7 @@
 		{
 			"importpath": "gopkg.in/yaml.v2",
 			"repository": "https://gopkg.in/yaml.v2",
+			"vcs": "",
 			"revision": "a83829b6f1293c91addabc89d0571c246397bbf4",
 			"branch": "v2",
 			"notests": true


### PR DESCRIPTION
Removes snapshots older than the given age, where default is 30 days.
You are required to set a `destination` flag, which represents the
environment where your snapshots are stored.