### PR TITLE
Take only aliased indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ it with the provided flag.
 Usage:
   esnap take [flags]
 
-  Flags:
-        --aliased             Take snapshot of indices with associated aliases only
-	  -a, --all                 Take snapshot of all indices. Otherwise, only those matching the destination
-	    -r, --create-repository   Create repository
+Flags:
+      --aliased             Take snapshot of indices with associated aliases only
+  -a, --all                 Take snapshot of all indices. Otherwise, only those matching the destination
+  -r, --create-repository   Create repository
 
-	    Global Flags:
-	          --config string        config file (default is $HOME/.esnap.yaml)
-		    -d, --destination string   Destination for the command action
+Global Flags:
+      --config string        config file (default is $HOME/.esnap.yaml)
+  -d, --destination string   Destination for the command action
 ```
 
 ### Restore a snapshot

--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ it with the provided flag.
 Usage:
   esnap take [flags]
 
-Flags:
-  -a, --all                 Take snapshot of all indices. Otherwise, only those matching the destination
-  -r, --create-repository   Create repository
+  Flags:
+        --aliased             Take snapshot of indices with associated aliases only
+	  -a, --all                 Take snapshot of all indices. Otherwise, only those matching the destination
+	    -r, --create-repository   Create repository
 
-Global Flags:
-      --config string        config file (default is $HOME/.esnap.yaml)
-  -d, --destination string   Destination for the command action
-
+	    Global Flags:
+	          --config string        config file (default is $HOME/.esnap.yaml)
+		    -d, --destination string   Destination for the command action
 ```
 
 ### Restore a snapshot

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ var RootCmd = &cobra.Command{
 var destination *string
 var createRepositoryTake *bool
 var originRestore, snapshot *string
-var allIndices, fresh *bool
+var allIndices, fresh, aliased *bool
 var age *int
 
 // Execute adds all child commands to the root command sets flags appropriately.

--- a/cmd/take_test.go
+++ b/cmd/take_test.go
@@ -36,3 +36,46 @@ func TestIndicesNames(t *testing.T) {
 		t.Errorf("got %v, expected %v", indicesNames, expectedIndicesNames)
 	}
 }
+
+func TestAliasedIndicesNames(t *testing.T) {
+	aliasesInfo := []es.CatAliasInfo{
+		{
+			Name:  "index0",
+			Index: "index0_123",
+		},
+		{
+			Name:  "index1",
+			Index: "index1_123",
+		},
+		{
+			Name:  "index2",
+			Index: "index2_123",
+		},
+		{
+			Name:  "index3",
+			Index: "index3_123",
+		},
+		{
+			Name:  "index4",
+			Index: "index4_123",
+		},
+	}
+
+	indicesNames := []string{
+		"index0_123", "index0_456",
+		"index1_123", "index1_456",
+		"index2_123", "index2_456",
+		"index3_123", "index3_456",
+		"index4_123", "index4_456",
+	}
+
+	expectedAliasedIndices := []string{
+		"index0_123", "index1_123", "index2_123",
+		"index3_123", "index4_123",
+	}
+
+	aliasedIndices := aliasedIndicesNames(aliasesInfo, indicesNames)
+	if !reflect.DeepEqual(aliasedIndices, expectedAliasedIndices) {
+		t.Errorf("got %v, expected %v", aliasedIndices, expectedAliasedIndices)
+	}
+}


### PR DESCRIPTION
Add `--aliased` flag to `take` command, so only indices which are linked to an alias are taken for the snapshot. It is compatible with the `--all` flag, so if both are set, it will take a snapshot of all indices with an alias, regardless of the origin.