### PR TITLE
take: Add snap id to error message.

### DIFF
--- a/cmd/take.go
+++ b/cmd/take.go
@@ -79,7 +79,7 @@ it with the provided flag.`,
 		for state != "SUCCESS" {
 			snapshots, err := conn.GetSnapshotByName(*destination, date, nil)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "take: error getting snapshot %s %v\n", *destination, err)
+				fmt.Fprintf(os.Stderr, "take: error getting snapshot %s, id %s %v\n", *destination, date, err)
 				os.Exit(1)
 			}
 


### PR DESCRIPTION
When the program fails in `take` command waiting for the snapshot to complete it fails with this error:

```
take: error getting snapshot preproduction record not found
```

It shows `*destination` which is the repository where the snapshot is being stored but does not show what was the expected id of the snap, a date string calculated.

This commit adds the date to the error message for helping debug, this allows knowing if the command failed because the expected snap was not there or if a problem in connection interrupted the program but the snapshot was taken successfully.